### PR TITLE
DbxCentral - LocalMetricsCollectorThread: stop subprocesses

### DIFF
--- a/src/com/asetune/Version.java
+++ b/src/com/asetune/Version.java
@@ -31,10 +31,10 @@ public class Version
 {
 	public static       String PRODUCT_STRING     = "AseTune";      // Do not have spaces etc in this one
 //	public static final String VERSION_STRING     = "4.5.0";        // Use this for public releases
-	public static final String VERSION_STRING     = "4.5.0.18.dev"; // Use this for early releases
-	public static final String BUILD_STRING       = "2023-08-22/build 468";
+	public static final String VERSION_STRING     = "4.5.0.19.dev"; // Use this for early releases
+	public static final String BUILD_STRING       = "2023-08-23/build 469";
 
-	public static final String GIT_DATE_STRING    = "2023-08-22";  // try to update this
+	public static final String GIT_DATE_STRING    = "2023-08-23";  // try to update this
 	public static final String GIT_REVISION_STR   = "600";         // used by CheckForUpdates --- update this on every check-in (emulates Subversion "Revision:" tag)
 
 	public static final boolean IS_DEVELOPMENT_VERSION  = true; // if true: date expiration will be checked on startup

--- a/src/com/asetune/central/lmetrics/LocalMetricsCollectorThread.java
+++ b/src/com/asetune/central/lmetrics/LocalMetricsCollectorThread.java
@@ -365,8 +365,16 @@ extends CounterCollectorThreadAbstract
 			// Sleep / wait for next sample
 			waitForNextSample(sleepTime * 1000);
 
-
 		} // END: while(_running)
+
+		// closing the CM's
+		for (CountersModel cm : getCounterController().getCmList())
+		{
+			_logger.info("DbxCentral Local Metrics - about to stop, closing CM '" + cm.getName() + "'.");
+			cm.close();
+		}
+
+		_logger.info("Stopped DbxCentral Local Metrics collector thread.");
 	}
 
 	private void sendDummyAlarmIfFileExists()

--- a/src/com/asetune/hostmon/HostMonitor.java
+++ b/src/com/asetune/hostmon/HostMonitor.java
@@ -1273,9 +1273,9 @@ implements Runnable
 		}
 		catch (Exception ignore) { /* ignore */ }
 
-		_logger.info("Closing Streaming SSH Session for '" + getModuleName() + "' with command '" + getCommand() + "'.");
+		_logger.info("Closing Streaming HostMon Session for '" + getModuleName() + "' with command '" + getCommand() + "' using Execution Wrapper '" + execWrapper.getClass().getSimpleName() + "'.");
 		execWrapper.close();
-		
+
 		_running = false;
 		printStopMessage();
 	}

--- a/src/com/asetune/hostmon/HostMonitorConnectionLocalOsCmd.java
+++ b/src/com/asetune/hostmon/HostMonitorConnectionLocalOsCmd.java
@@ -411,7 +411,16 @@ extends HostMonitorConnection
 
 			// Kill the process if it's still there
 			if (_proc.isAlive())
+			{
+				if (_logger.isDebugEnabled())
+					_logger.debug("HostMonitorConnectionLocalOsCmd: Killing subprocess... _pb.commad()=" + _pb.command() + ", cmd=[" + _name + "].");
 				_proc.destroy();
+			}
+			else
+			{
+				if (_logger.isDebugEnabled())
+					_logger.debug("HostMonitorConnectionLocalOsCmd: No need to kill subprocess... _proc.isAlive()=false.");
+			}
 
 //			_pb.close();
 		}

--- a/src/com/asetune/hostmon/HostMonitorConnectionLocalOsCmdWrapper.java
+++ b/src/com/asetune/hostmon/HostMonitorConnectionLocalOsCmdWrapper.java
@@ -698,7 +698,16 @@ extends HostMonitorConnectionLocalOsCmd
 
 			// Kill the process if it's still there
 			if (_proc.isAlive())
+			{
+				if (_logger.isDebugEnabled())
+					_logger.debug("HostMonitorConnectionLocalOsCmdWrapper: Killing subprocess... _pb.commad()=" + _pb.command() + ", cmd=[" + _name + "].");
 				_proc.destroy();
+			}
+			else
+			{
+				if (_logger.isDebugEnabled())
+					_logger.debug("HostMonitorConnectionLocalOsCmdWrapper: No need to kill subprocess... _proc.isAlive()=false.");
+			}
 
 //			_pb.close();
 		}


### PR DESCRIPTION
DbxCentral - LocalMetricsCollectorThread: on stop it did not stop the streaming local processes, hence left hangen 'iostat', 'vmstat', and 'mpstat' processes... This is now fixed!