### PR TITLE
Following changes in this checkin

### DIFF
--- a/README_dbxcentral_install.txt
+++ b/README_dbxcentral_install.txt
@@ -364,17 +364,22 @@ for example: http://dbxtune.acme.com:8080/
 	use master;
 	CREATE USER [dbxtune] FOR LOGIN [dbxtune];
 	GRANT EXEC ON xp_readerrorlog TO [dbxtune];
-
+	
 	## Note: If you want to inspect 'Job Scheduler', dbxtune needs access to database 'msdb' 
 	USE msdb;
 	CREATE USER dbxtune FOR LOGIN dbxtune;
 	ALTER ROLE db_datareader ADD MEMBER dbxtune;
 
+	## and sp_Blitz* (if you havn't got them installed, now would be a good time: https://www.brentozar.com/blitz/ )
 	## Note: If you want to execute 'sp_blitz' and are using a non 'sysadmin' account (like we do above with the login 'dbxtune')
 	## you need to follow 'https://www.brentozar.com/askbrent/', look for 'How to Grant Permissions to Non-DBAs'
 	## The 'sp_blitz' may be used to do all sorts of 'healthchecks' every time you connect to the monitored server.
 	use master;
-	GRANT EXEC ON sp_blitz TO [dbxtune];
+	GRANT EXEC ON sp_Blitz      TO [dbxtune];  -- Used for quick health check
+	GRANT EXEC ON sp_BlitzLock  TO [dbxtune];  -- Used to list deadlocks (for Daily Summary Reports, if we have had deadlocks during that day)
+	GRANT EXEC ON sp_BlitzIndex TO [dbxtune];  -- [not used by dbxtune yet] -- To get some Index Information
+	GRANT EXEC ON sp_BlitzCache TO [dbxtune];  -- [not used by dbxtune yet] -- To get info from the Plan Cache
+	GRANT EXEC ON sp_BlitzFirst TO [dbxtune];  -- [not used by dbxtune yet] -- To ...
 
 	## Test that we can login to SQL Server with the 'dbxtune' user
 	sqlcmd -Ssrvname -Udbxtune -Pthe_long_and_arbitrary_password

--- a/src/com/asetune/Version.java
+++ b/src/com/asetune/Version.java
@@ -31,10 +31,10 @@ public class Version
 {
 	public static       String PRODUCT_STRING     = "AseTune";      // Do not have spaces etc in this one
 //	public static final String VERSION_STRING     = "4.5.0";        // Use this for public releases
-	public static final String VERSION_STRING     = "4.5.0.27.dev"; // Use this for early releases
-	public static final String BUILD_STRING       = "2023-10-06/build 477";
+	public static final String VERSION_STRING     = "4.5.0.29.dev"; // Use this for early releases
+	public static final String BUILD_STRING       = "2023-10-18/build 479";
 
-	public static final String GIT_DATE_STRING    = "2023-10-06";  // try to update this
+	public static final String GIT_DATE_STRING    = "2023-10-18";  // try to update this
 	public static final String GIT_REVISION_STR   = "600";         // used by CheckForUpdates --- update this on every check-in (emulates Subversion "Revision:" tag)
 
 	public static final boolean IS_DEVELOPMENT_VERSION  = true; // if true: date expiration will be checked on startup

--- a/src/com/asetune/alarm/events/AlarmEventDeadlock.java
+++ b/src/com/asetune/alarm/events/AlarmEventDeadlock.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (C) 2010-2019 Goran Schwarz
+ * 
+ * This file is part of DbxTune
+ * DbxTune is a family of sub-products *Tune, hence the Dbx
+ * Here are some of the tools: AseTune, IqTune, RsTune, RaxTune, HanaTune, 
+ *          SqlServerTune, PostgresTune, MySqlTune, MariaDbTune, Db2Tune, ...
+ * 
+ * DbxTune is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * DbxTune is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with DbxTune.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package com.asetune.alarm.events;
+
+import com.asetune.Version;
+import com.asetune.cm.CountersModel;
+
+public class AlarmEventDeadlock
+extends AlarmEvent 
+{
+	private static final long serialVersionUID = 1L;
+
+	public AlarmEventDeadlock(CountersModel cm, double threshold, int movingAverageInMinutes, int deadlockCount, double movingAvgDeadlockCount)
+	{
+		super(
+				Version.getAppName(), // serviceType
+				cm.getServerName(),   // serviceName
+				cm.getName(),         // serviceInfo
+				null,                 // extraInfo
+				AlarmEvent.Category.LOCK,
+				AlarmEvent.Severity.INFO, 
+				AlarmEvent.ServiceState.UP, 
+				"Some deadlock(s) was detected in Server '" + cm.getServerName() + "', DeadlockCount=" + deadlockCount + ", movingAvgDeadlockCount=" + movingAvgDeadlockCount + " (movingAverageInMinutes=" + movingAverageInMinutes + "), threshold=" + threshold,
+				threshold
+				);
+
+		// Set: Time To Live if postpone is enabled
+		setTimeToLive(cm);
+
+		// Set the raw data
+		setData("deadlockCount=" + deadlockCount + ",movingAvgDeadlockCount='" + movingAvgDeadlockCount + "'.");
+	}
+}

--- a/src/com/asetune/cm/sqlserver/CmActiveStatements.java
+++ b/src/com/asetune/cm/sqlserver/CmActiveStatements.java
@@ -1494,6 +1494,17 @@ System.out.println("Can't find the position for columns ('StartTime'="+pos_Start
 
 						boolean onlySendAlarmForExclusiveLocks = Configuration.getCombinedConfiguration().getBooleanProperty(PROPKEY_alarm_HoldingLocksWhileWaitForClientInputInSecX, DEFAULT_alarm_HoldingLocksWhileWaitForClientInputInSecX);
 
+						// TODO; // Possibly add "skip" on below column names
+						// +---------------+----------------+
+						// |Column Name    |Ex Column Value |
+						// +---------------+----------------+
+						// |tran_name      |user_transaction|
+						// |ProcName       |WriteLockSession|
+						// |HOST_NAME      |MM-OP-SSRS      |
+						// |database_name  |ReportServer    |
+						// |program_name   |Report Server   |
+						// +---------------+----------------+
+						
 						if ( (onlySendAlarmForExclusiveLocks && hasExlusiveLocks) || onlySendAlarmForExclusiveLocks == false )
 						{
 							String extendedDescText = cm.toTextTableString(DATA_RATE, r);

--- a/src/com/asetune/cm/sqlserver/gui/CmSummaryPanel.java
+++ b/src/com/asetune/cm/sqlserver/gui/CmSummaryPanel.java
@@ -159,6 +159,9 @@ implements ISummaryPanel, TableModelListener, GTabbedPane.ShowProperties
 	private JLabel           _lockWaits_lbl                             = new JLabel();
 	private JTextField       _rootBlockerSpids_txt                      = new JTextField();
 	private JLabel           _rootBlockerSpids_lbl                      = new JLabel();
+	private JTextField       _deadlockCount_txt                         = new JTextField();
+	private JTextField       _deadlockCountDiff_txt                     = new JTextField();
+	private JLabel           _deadlockCount_lbl                         = new JLabel();
 	private JLabel           _fullTranslog_lbl                          = new JLabel();
 	private JTextField       _fullTranslog_txt                          = new JTextField();
 	                                                                    
@@ -550,6 +553,19 @@ implements ISummaryPanel, TableModelListener, GTabbedPane.ShowProperties
 		_rootBlockerSpids_txt.setToolTipText(tooltip);
 		_rootBlockerSpids_txt.setEditable(false);
 
+		tooltip = "<html>Number Deadlocks on this instance.<br>"
+				+ "If you have a deadlock <i>problem</i>, please run 'sp_blitzLock' from Brent Ozar's package 'First Responder Kit'...<br>"
+				+ "<br>"
+				+ "To find that package and how to use it; simply Google 'sp_blitzLock'.<br>"
+				+ "It will give you <i>details</i> and <i>summary</i> of what tables/SQL/procs that is responsible for the deadlocks.</html>";
+		_deadlockCount_lbl        .setText("Deadlocks");
+		_deadlockCount_lbl        .setToolTipText(tooltip);
+		_deadlockCount_txt        .setToolTipText(tooltip);
+		_deadlockCount_txt        .setEditable(false);
+		_deadlockCountDiff_txt    .setEditable(false);
+		_deadlockCountDiff_txt    .setToolTipText("The difference since previous sample.");
+		_deadlockCountDiff_txt.setForeground(Color.BLUE);
+		
 
 		//-----------------------------------------------------------------------------------
 		tooltip = "Number of databases that has a full transaction log, which probably means suspended SPID's.";
@@ -983,6 +999,10 @@ implements ISummaryPanel, TableModelListener, GTabbedPane.ShowProperties
 		panel.add(_rootBlockerSpids_lbl,                      "");
 		panel.add(_rootBlockerSpids_txt,                      "growx, wrap");
                                                               
+		panel.add(_deadlockCount_lbl,                         "");
+		panel.add(_deadlockCount_txt,                         "growx, split");
+		panel.add(_deadlockCountDiff_txt,                     "growx, wrap");
+		                                                      
 		panel.add(_fullTranslog_lbl,                          "");
 		panel.add(_fullTranslog_txt,                          "growx, wrap");
                                                               
@@ -1254,6 +1274,8 @@ implements ISummaryPanel, TableModelListener, GTabbedPane.ShowProperties
 		_lockWaits_txt                          .setText(cm.getAbsString (0, "LockWaits"));
 		_lockWaitsDiff_txt                      .setText(cm.getDiffString(0, "LockWaits"));
 		_rootBlockerSpids_txt                   .setText(cm.getAbsString (0, "RootBlockerSpids"));  _rootBlockerSpids_txt.setCaretPosition(0);
+		_deadlockCount_txt                      .setText(cm.getAbsString (0, "deadlockCount"));
+		_deadlockCountDiff_txt                  .setText(cm.getDiffString(0, "deadlockCount"));
 		_fullTranslog_txt                       .setText(cm.getAbsString (0, "fullTranslogCount"));
 		
 		_tempdbUsageMbAllAbs_txt		        .setText(cm.getAbsString (0, "tempdbUsageMbAll"));
@@ -1490,6 +1512,39 @@ if (StringUtil.hasValue(_oldestOpenTranId_txt.getText()) && "goran".equals(Syste
 		}
 		// end: Check LOCK WAITS and, do notification
 
+		
+		
+		//----------------------------------------------
+		// Check DEADLOCK and, do notification
+		//----------------------------------------------
+		int deadlockCount = StringUtil.parseInt(_deadlockCountDiff_txt.getText(), 0);
+		_logger.debug("DEADLOCK-COUNT-DIFF="+deadlockCount+", TEXT='"+_deadlockCountDiff_txt.getText()+"'.");
+		if (deadlockCount > 0)
+		{
+			_deadlockCount_txt       .setBackground(Color.RED);
+			_deadlockCountDiff_txt   .setBackground(Color.RED);
+
+//			boolean isVisibleInPrevSample = MainFrame.getInstance().hasDeadlocks();
+//			MainFrame.getInstance().setDeadlocks(true, deadlockCount);
+
+//			String toTabName = "Active Statements";
+//			if ( _focusToBlockingTab == null )
+//				_focusToBlockingTab = new ChangeToJTabDialog(MainFrame.getInstance(), "Found Blocking Locks in the SQL-Server", cm.getGuiController().getTabbedPane(), toTabName);
+//
+//			if ( ! isVisibleInPrevSample )
+//				_focusToBlockingTab.setVisible(true);
+		}
+		else
+		{
+			_deadlockCount_txt       .setBackground(_atAtServerName_txt.getBackground());
+			_deadlockCountDiff_txt   .setBackground(_atAtServerName_txt.getBackground());
+
+//			MainFrame.getInstance().setDeadlocks(false, 0);
+		}
+		// end: Check DEADLOCKS and, do notification
+
+
+		
 		//----------------------------------------------
 		// Check FULL LOGS and, do notification
 		//----------------------------------------------
@@ -1589,6 +1644,8 @@ if (StringUtil.hasValue(_oldestOpenTranId_txt.getText()) && "goran".equals(Syste
 		_lockWaits_txt                            .setText("");
 		_lockWaitsDiff_txt                        .setText("");
 		_rootBlockerSpids_txt                     .setText("");
+		_deadlockCount_txt                        .setText("");
+		_deadlockCountDiff_txt                    .setText("");
 		_fullTranslog_txt                         .setText("");
                                                   
 		_tempdbUsageMbAllAbs_txt                  .setText("");

--- a/src/com/asetune/config/dbms/PostgresConfig.java
+++ b/src/com/asetune/config/dbms/PostgresConfig.java
@@ -745,6 +745,23 @@ extends DbmsConfigAbstract
 
 		
 		//-------------------------------------------------------
+		cfgName = "fsync";
+		entry = _configMap.get(cfgName);
+		if (entry != null)
+		{
+			if ("off".equalsIgnoreCase(entry.configValue))
+			{
+				String key = "DbmsConfigIssue." + srvName + ".pg_settings." + cfgToPropName(cfgName) + ".off";
+
+				DbmsConfigIssue issue = new DbmsConfigIssue(srvRestart, key, cfgName, Severity.ERROR, 
+						"The Server Level Configuration '" + cfgName + "' is 'OFF'. You will loose data in case of a power failure.", 
+						"Fix this using: Set configuration '" + cfgName + "' to 'on'.");
+
+				DbmsConfigManager.getInstance().addConfigIssue(issue);
+			}
+		}
+		
+		//-------------------------------------------------------
 		cfgName = "synchronous_commit";
 		entry = _configMap.get(cfgName);
 		if (entry != null)
@@ -760,7 +777,7 @@ extends DbmsConfigAbstract
 				DbmsConfigManager.getInstance().addConfigIssue(issue);
 			}
 		}
-
+		
 		//-------------------------------------------------------
 		cfgName = "shared_buffers"; // default value '???' but if it's less than 25% of the memory on the HW. 
 		// This extension might be useful to get OS Memory --->>>> https://github.com/EnterpriseDB/system_stats
@@ -784,7 +801,7 @@ extends DbmsConfigAbstract
 
 		
 		//-------------------------------------------------------
-		cfgName = "effective_cache_size"; // default value '4G' should be approc 75% of physical memory (or: shared_buffers + filesystem-cache) 
+		cfgName = "effective_cache_size"; // default value '4G' should be approx 75% of physical memory (or: shared_buffers + filesystem-cache) 
 		// This extension might be useful to get OS Memory --->>>> https://github.com/EnterpriseDB/system_stats
 		entry = _configMap.get(cfgName);
 		if (entry != null)
@@ -847,6 +864,10 @@ extends DbmsConfigAbstract
 		// TODO in the future
 		cfgName = "min_parallel_table_scan_size"; // is probably set to low  
 		cfgName = "min_parallel_index_scan_size"; // is probably set to low  
+
+		//check: 'maintenance_work_mem'   DEfault: 64MB, could be much higher (used for create index, vacuum etc)
+		//check: 'work_mem' should not be to high (per sort, not per connection) 
+		//check: 'checkpoint_completion_target' Default=0.5 ...For dedicated systems, with good I/O: 0.8
 
 	}
 

--- a/src/com/asetune/config/dbms/SqlServerConfigText.java
+++ b/src/com/asetune/config/dbms/SqlServerConfigText.java
@@ -1388,7 +1388,7 @@ public abstract class SqlServerConfigText
 				    + "          , @Params = N'@dbname NVARCHAR(128) OUTPUT' \n"
 				    + "          , @dbname = @dbname OUTPUT \n"
 				    + "     \n"
-				    + "    END \n"
+				    + "END \n"
 				    + " \n"
 				    + "/* if NOT found anywhere... print some info */ \n"
 				    + "IF (@dbname is NULL) \n"

--- a/src/com/asetune/history.html
+++ b/src/com/asetune/history.html
@@ -90,6 +90,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 				<LI>In the Recording Information section Write what Java version we used.</LI>
 				<LI>Introduced a "priority queue", so that not to many DbxTune collectors does DSR at the same time, which causes extensive CPU usage and possibly memory issues</LI>
 				<LI>When generating SparcLines, introduced a timeout of 10 minutes... and prints SQL for easier debugging.</LI>
+				<LI>In the 'Exec/Creation time for each Report Section' also print aprox how many bytes we have written to each section</LI>
 			</UL>
 		</LI>
 
@@ -246,6 +247,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI>Added Alarm: <b>AlarmEventLowOnWorkerThreads</b> -- which will be raised when we have 20 or less "worker threads" available (called from CmSummary)</LI>
 		<LI>Added Alarm: <b>AlarmEventOutOfWorkerThreads</b> -- which will be raised when we have no more "worker threads" available (called from CmSummary)</LI>
 		<LI>Added Alarm: <b>AlarmEventToxicWait         </b> -- which will be raised when checking "Server Wait Time", wait events (called from CmWaitStats)</LI>
+		<LI>Added Alarm: <b>AlarmEventDeadlock          </b> -- if we had any deadlocks... (within a MovingAverage over 10 minutes), (called from CmSummary)</LI>
 
 		<LI>Added CM: <b>CmExecQueryStatPerDb </b> - Activity Grouped by Database -- Information is fetched from dm_exec_query_stats</LI>
 
@@ -283,6 +285,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI><b>CmOpenTransactions   </b> - added new column 'context_info_str' which is a String interpretation of the binary field 'context_info'</LI>
 
 		<LI><b>CmPerfCounters       </b> - Added Chart 'Stolen Server Memory, from Buffer Pool'</LI>
+		<LI><b>CmPerfCounters       </b> - Added Chart 'DeadlockDetails'</LI>
 
 		<LI><b>CmSessions           </b> - The "hidden report" on WaitResources has been extended (can now lookup pages to get ObjectID's and translated to ObjectName's, also lookup 'locked data' when WaitResource is 'KEY')</LI>
 		<LI><b>CmSessions           </b> - added new column 'context_info_str' which is a String interpretation of the binary field 'context_info'</LI>
@@ -293,9 +296,12 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI><b>CmSummary            </b> - added Chart "WorkersThreadUsage"  -- to see the behaviour of Worker Thread Usage</LI>
 		<LI><b>CmSummary            </b> - added Chart "WtWaitingForCpu"     -- SQL Server Worker That are Waiting for CPU to be Scheduled</LI>
 		<LI><b>CmSummary            </b> - added Chart "TasksWaitForWorkers" -- Tasks/Requests that are Waiting for Available Worker Threads</LI>
+		<LI><b>CmSummary            </b> - added Chart "DeadlockCountSum"    -- How many deadlocks did we have in last "sample"</LI>
 		<LI><b>CmSummary            </b> - new columns: RootBlockerSpids</LI>
+		<LI><b>CmSummary            </b> - new columns: deadlockCount</LI>
 		<LI><b>CmSummary            </b> - alarm 'AlarmEventBlockingLockAlarm', attach info from "CmSessions" about "RootBlockerSpids" and "oldestOpenTranSpid"</LI>
 		<LI><b>CmSummary            </b> - alarm 'AlarmEventLongRunningTransaction', attach info from "CmSessions" about "oldestOpenTranSpid"</LI>
+		<LI><b>CmSummary            </b> - alarm 'AlarmEventDeadlock' if we had any deadlocks... (within a MovingAverage over 10 minutes) </LI>
 
 		<LI><b>CmTempdbSpidUsage    </b> - added new column 'context_info_str' which is a String interpretation of the binary field 'context_info'</LI>
 
@@ -314,14 +320,15 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<b>Daily Report</b><br>
 		<ul>
 			<li>New section: Top Database Activity (order by: 'total_worker_time_ms__sum', origin: CmExecQueryStatPerDb/dm_exec_query_stats)</li>
-			<li>new: SqlServerXxxYyy       -- xxx</li>
+			<li>New section 'Deadlocks', which prints how many deadlocks we had in last 24 hours, and print information we got from sp_BlitzLock</li>
 			<li>new: SqlServerXxxYyy       -- xxx</li>
 
 			<li>In the Recording info, Print the Edition: 'Standard Edition', 'Enterprise Edition', 'Web Edition', 'Developer Edition', 'Express Edition', or 'Azure'</li>
 			<li>In the Recording info, Print the 'Collation Name' and 'Collation Description'</li>
 			<li>In the "Overview" section, added some Graphs: 'CmPerfCounters_CachePhyReads', 'CmPerfCounters_CacheWrites', 'CmMemoryGrantsSum_GrantedMemSum' and 'CmSummary_OsMemoryFreeMb'</li>
 			<li>In the "Plan Cache History"" is no longer included in "short" report (Mail Reports)</li>
-
+			<li>In the "QueryStore" and "TopCmExecQueryStats" new column 'efficiency_pct' for  this may help decide if we have (parallel) queries that are NOT effective</li>
+			<li>PCS - On Database Rollover, If we have seen any Deadlocks... extract them using 'sp_BlitzLock' and store them in the recording.</li>
 		</ul>                                                              
 		</LI>
 	</UL>
@@ -374,6 +381,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 
 		<br>
 		<LI><b>DBMS Configuration   </b> - Added some Text config: 'DB Info', 'HBA Conf', 'Extentions', 'Servers'</LI> 
+		<LI><b>DBMS Configuration   </b> - Warn about 'fsync=off'</LI> 
 
 		<br>
 		<LI><b>DDL Lookup/Store     </b> - xxx</LI> 
@@ -409,6 +417,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 	<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 	<UL>
 		<LI>Table/Cell ToolTip Better support to handle/display inline HTML content that dosn't start with '&gt;html&lt;'</LI>
+		<LI>The "Copy Result" button can now also copy ResultSets into a JSON format (long or short)</LI>
 	</UL>
 	<!-- ~~~end-of-this-tool~~~ -->
 

--- a/src/com/asetune/hostmon/MonitorIoLinux.java
+++ b/src/com/asetune/hostmon/MonitorIoLinux.java
@@ -407,7 +407,16 @@ extends MonitorIo
 
 		// Skip "loop" devices
 		if (Configuration.getCombinedConfiguration().getBooleanProperty("hostmon.MonitorIo.skipLoopDevices", true))
-			md.setSkipRows("device", "^loop[0-9]+");
+		{
+			md.setSkipRows("Device", "^loop[0-9]+");
+			md.setSkipRows("Device", "^/dev/loop[0-9]+");
+		}
+
+		// Skip "tmpfs" devices
+		if (Configuration.getCombinedConfiguration().getBooleanProperty("hostmon.MonitorIo.skip.tmpfs.devices", true))
+		{
+			md.setSkipRows("Device", "^tmpfs");
+		}
 
 		// Get SKIP and ALLOW from the Configuration
 		md.setSkipAndAllowRows(null, Configuration.getCombinedConfiguration());

--- a/src/com/asetune/pcs/PersistReader.java
+++ b/src/com/asetune/pcs/PersistReader.java
@@ -3403,8 +3403,6 @@ implements Runnable, ConnectionProvider
 
 		return list;
 	}
-
-
 	/*---------------------------------------------------
 	** END: DDL reader
 	**---------------------------------------------------

--- a/src/com/asetune/pcs/report/DailySummaryReportSqlServerTune.java
+++ b/src/com/asetune/pcs/report/DailySummaryReportSqlServerTune.java
@@ -38,6 +38,7 @@ import com.asetune.pcs.report.content.sqlserver.SqlServerCmDeviceIo;
 import com.asetune.pcs.report.content.sqlserver.SqlServerConfiguration;
 import com.asetune.pcs.report.content.sqlserver.SqlServerCpuUsageOverview;
 import com.asetune.pcs.report.content.sqlserver.SqlServerDbSize;
+import com.asetune.pcs.report.content.sqlserver.SqlServerDeadlocks;
 import com.asetune.pcs.report.content.sqlserver.SqlServerMissingIndexes;
 import com.asetune.pcs.report.content.sqlserver.SqlServerPlanCacheHistory;
 import com.asetune.pcs.report.content.sqlserver.SqlServerQueryStore;
@@ -75,6 +76,7 @@ extends DailySummaryReportDefault
 		
 		// SQL
 		addReportEntry( new SqlServerPlanCacheHistory       (this));        // Check if the Plan Cache can be trusted... https://www.brentozar.com/archive/2018/07/tsql2sday-how-much-plan-cache-history-do-you-have/
+		addReportEntry( new SqlServerDeadlocks              (this));
 //		addReportEntry( new SqlServerTopCmExecQueryStatsDb  (this)); // Older version of the "DB" statistics
 		addReportEntry( new SqlServerTopCmExecQueryStatPerDb(this));
 		addReportEntry( new SqlServerTopCmExecQueryStats    (this, SqlServerTopCmExecQueryStats.ReportType.CPU_TIME));

--- a/src/com/asetune/pcs/report/DsrPriority.java
+++ b/src/com/asetune/pcs/report/DsrPriority.java
@@ -71,8 +71,9 @@ implements AutoCloseable
 
 	public static final String  PROPKEY_priorityCoreCountParallelFactor = "DailySummaryReport.priority.core.count.parallel.factor";
 //	public static final double  DEFAULT_priorityCoreCountParallelFactor = 0.4; // this is "modest" and probably to under-allocated
+	public static final double  DEFAULT_priorityCoreCountParallelFactor = 0.5; // 50 % ... might be good since we do shutdown "compress" after as well
 //	public static final double  DEFAULT_priorityCoreCountParallelFactor = 0.6; // slightly under-allocated
-	public static final double  DEFAULT_priorityCoreCountParallelFactor = 0.7; // probably the right choice
+//	public static final double  DEFAULT_priorityCoreCountParallelFactor = 0.7; // probably the right choice
 //	public static final double  DEFAULT_priorityCoreCountParallelFactor = 0.8; // probably the right choice
 //	public static final double  DEFAULT_priorityCoreCountParallelFactor = 1.0; // 1 to 1 (but we are using more thread so this will over-allocate)
 //	public static final double  DEFAULT_priorityCoreCountParallelFactor = 1.2; // more over-allocation

--- a/src/com/asetune/pcs/report/content/IReportEntry.java
+++ b/src/com/asetune/pcs/report/content/IReportEntry.java
@@ -270,4 +270,26 @@ public interface IReportEntry
 	 * @return The previous value, if not previously set it will be null
 	 */
 	Object setStatusEntry(String statusKey);
+	
+	/**
+	 * Called at start of writing a Report Entry, so we can track some statistics
+	 * @param writer
+	 * @param fullMessage
+	 */
+	void beginWriteEntry(Writer writer, MessageType messageType);
+
+	/**
+	 * Called at start of writing a Report Entry, so we can track some statistics
+	 * @param writer
+	 * @param fullMessage
+	 */
+	void endWriteEntry(Writer writer, MessageType messageType);
+
+	/**
+	 * Get how many characters (in KB) that was written in this section
+	 * 
+	 * @param messageType
+	 * @return Number of chars written
+	 */
+	long getCharsWrittenKb(MessageType messageType);
 }

--- a/src/com/asetune/pcs/report/content/sqlserver/SqlServerCpuUsageOverview.java
+++ b/src/com/asetune/pcs/report/content/sqlserver/SqlServerCpuUsageOverview.java
@@ -28,7 +28,6 @@ import com.asetune.pcs.report.DailySummaryReportAbstract;
 import com.asetune.pcs.report.content.IReportChart;
 import com.asetune.sql.conn.DbxConnection;
 import com.asetune.utils.Configuration;
-import com.asetune.utils.StringUtil;
 
 public class SqlServerCpuUsageOverview 
 extends SqlServerAbstract
@@ -99,6 +98,7 @@ extends SqlServerAbstract
 		_CmSummary_OsMemoryFreeMb       .writeHtmlContent(w, null, null);
 		_CmPerfCounters_SqlBatch        .writeHtmlContent(w, null, null);
 		_CmPerfCounters_TransWriteSec   .writeHtmlContent(w, null, null);
+
 		if (isFullMessageType())
 		{
 			_CmSchedulers_RunQLengthSum   .writeHtmlContent(w, null, null);
@@ -161,7 +161,7 @@ extends SqlServerAbstract
 		_CmSchedulers_RunQLengthSum      = createTsLineChart(conn, schema, "CmSchedulers",      "RunQLengthSum",    -1,       false, null,    "Runnable Queue Length, Summary (using dm_os_schedulers.runnable_tasks_count)");
 		_CmSchedulers_RunQLengthEng      = createTsLineChart(conn, schema, "CmSchedulers",      "RunQLengthEng",    -1,       false, null,    "Runnable Queue Length, per Scheduler (using dm_os_schedulers.runnable_tasks_count)");
 	}
-
+	
 	private IReportChart _CmSummary_aaCpuGraph;
 	private IReportChart _CmOsMpstat_MpSum;
 	private IReportChart _CmSummary_aaReadWriteGraph;

--- a/src/com/asetune/pcs/report/content/sqlserver/SqlServerDeadlocks.java
+++ b/src/com/asetune/pcs/report/content/sqlserver/SqlServerDeadlocks.java
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ * Copyright (C) 2010-2020 Goran Schwarz
+ * 
+ * This file is part of DbxTune
+ * DbxTune is a family of sub-products *Tune, hence the Dbx
+ * Here are some of the tools: AseTune, IqTune, RsTune, RaxTune, HanaTune, 
+ *          SqlServerTune, PostgresTune, MySqlTune, MariaDbTune, Db2Tune, ...
+ * 
+ * DbxTune is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * DbxTune is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with DbxTune.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package com.asetune.pcs.report.content.sqlserver;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.log4j.Logger;
+
+import com.asetune.CounterControllerSqlServer;
+import com.asetune.gui.ResultSetTableModel;
+import com.asetune.pcs.PersistWriterJdbc;
+import com.asetune.pcs.report.DailySummaryReportAbstract;
+import com.asetune.pcs.report.content.IReportChart;
+import com.asetune.pcs.report.content.ReportEntryAbstract.ReportEntryTableStringRenderer;
+import com.asetune.sql.conn.DbxConnection;
+import com.asetune.utils.Configuration;
+import com.asetune.utils.StringUtil;
+
+public class SqlServerDeadlocks 
+extends SqlServerAbstract
+{
+	private static Logger _logger = Logger.getLogger(SqlServerDeadlocks.class);
+
+	public SqlServerDeadlocks(DailySummaryReportAbstract reportingInstance)
+	{
+		super(reportingInstance);
+	}
+
+	@Override
+	public boolean hasShortMessageText()
+	{
+		return true;
+	}
+
+	@Override
+	public void writeMessageText(Writer w, MessageType messageType)
+	throws IOException
+	{
+		if (_deadlockSummaryPeriodCount > 0)
+		{
+			// in RED
+			w.append("<p style='color:red'><b>Found " + _deadlockSummaryPeriodCount + " Deadlocks in the recording period...</b></p>");
+
+			w.append(getDbxCentralLinkWithDescForGraphs(false, "Below are Deadlock Count Graphs/Charts, to indicate when on the hour you have problems",
+					"CmSummary_DeadlockCountSum",
+					"CmPerfCounters_DeadlockDetails"
+					));
+
+			if (_CmSummary_DeadlockCountSum     != null) _CmSummary_DeadlockCountSum    .writeHtmlContent(w, null, null);
+			if (_CmPerfCounters_DeadlockDetails != null) _CmPerfCounters_DeadlockDetails.writeHtmlContent(w, null, null);
+
+			// sp_BlitzLock info
+			if (StringUtil.hasValue(_deadlockSummaryPeriodReport_spBlitzLock))
+			{
+				w.append("<p>Below are some Deadlock Information from: sp_BlitzLock</p>");
+
+				//---------------------------------------------------------
+				// Section 3 is HIGH Level or SUMMARY, so it goes first
+				//---------------------------------------------------------
+				if (_spBlitzLock_section3 != null)
+				{
+//					w.append("<p><b>A high-level analysis of all the stuff we pull out.</b></p>");
+//					w.append(_spBlitzLock_section3.toHtmlTableString("sortable"));
+					
+					String  divId       = "DeadlockSummary";
+					boolean showAtStart = true;
+					String  htmlContent = _spBlitzLock_section3.toHtmlTableString("sortable");
+
+					String showHideDiv = createShowHideDiv(divId, showAtStart, "<b>A high-level analysis of all the stuff we pull out.</b> (" + _spBlitzLock_section3.getRowCount() + " rows)", htmlContent);
+					w.append( msOutlookAlternateText(showHideDiv, divId, null) );
+				}
+
+				//---------------------------------------------------------
+				// Section 1 is Details
+				//---------------------------------------------------------
+				if (_spBlitzLock_section1 != null)
+				{
+					w.append("<p></p>");
+//					w.append("<p><b>Below are each of the deadlocks</b></p>");
+
+					ReportEntryTableStringRenderer tableRender = new ReportEntryTableStringRenderer()
+					{
+						@Override
+						public String cellValue(ResultSetTableModel rstm, int row, int col, String colName, Object objVal, String strVal)
+						{
+							if (    "query"                    .equals(colName) // starts with "<?query \n" and ends with "?>"
+							     || "object_names"             .equals(colName) // "<object>tempdb.dbo.deadlock_right</object>"
+							     || "parallel_deadlock_details".equals(colName) // "<parallel_deadlock_details/>"
+							     || "deadlock_graph"           .equals(colName) // "<deadlock>...</deadlock>"
+							   ) 
+							{
+								String htmlClassName = "class='dbx-xml-text-cell'";
+
+								if ("query".equals(colName))
+								{
+									strVal = strVal.replace("<?query ", "").replace("  ?>", ""); // remove: prefix/suffix
+									htmlClassName = "class='dbx-sql-text-cell'";
+								}
+
+								if ("deadlock_graph".equals(colName)) // "<deadlock>...</deadlock>"
+								{
+									strVal = StringUtil.xmlFormat(strVal);
+								}
+
+//								strVal = "<pre class='language-xml'>" + StringEscapeUtils.escapeHtml4(strVal) + "</pre>";
+								strVal = "<pre " + htmlClassName + ">" + StringEscapeUtils.escapeHtml4(strVal) + "</pre>";
+							}
+							
+							// Make client_option_# a UnOrdered List
+							if (colName != null && colName.startsWith("client_option_"))
+							{
+								String unorderedListStr = "<ul> \n";
+								for (String str : StringUtil.parseCommaStrToList(strVal, true))
+									unorderedListStr += "  <li>" + str + "</li> \n";
+								unorderedListStr += "</ul> \n";
+								
+								strVal = unorderedListStr;
+							}
+
+						//	if ("deadlock_graph".equals(colName))
+						//	{
+						//		//TODO; // can we make a button/link for column "deadlock_graph" to "Download" or "Open in SSMS/SqlSentry" to view the XML deadlock reports
+						//	}
+
+							return strVal;
+						}
+						
+					};
+//					w.append(_spBlitzLock_section1.toHtmlTableString("sortable", true, true, null, tableRender));
+					
+					String  divId       = "DeadlockDetails";
+					boolean showAtStart = false;
+					String  htmlContent = _spBlitzLock_section1.toHtmlTableString("sortable", true, true, null, tableRender);
+
+					String showHideDiv = createShowHideDiv(divId, showAtStart, "<b>Below are each of the deadlocks</b> (" + _spBlitzLock_section1.getRowCount() + " rows)", htmlContent);
+					w.append( msOutlookAlternateText(showHideDiv, divId, null) );
+				}
+
+				//---------------------------------------------------------
+				// Section 2 is info from "plan cache"
+				//---------------------------------------------------------
+				if (_spBlitzLock_section2 != null)
+				{
+					w.append("<p></p>");
+//					w.append("<p><b>This section holds information about the statements (if they are still in the Cache Plan)</b></p>");
+//					w.append(_spBlitzLock_section2.toHtmlTableString("sortable"));
+
+					String  divId       = "DeadlockFromPlanCache";
+					boolean showAtStart = false;
+					String  htmlContent = _spBlitzLock_section2.toHtmlTableString("sortable");
+
+					String showHideDiv = createShowHideDiv(divId, showAtStart, "<b>This section holds information about the statements (if they are still in the Cache Plan)</b> (" + _spBlitzLock_section2.getRowCount() + " rows)", htmlContent);
+					w.append( msOutlookAlternateText(showHideDiv, divId, null) );
+				}
+			}
+			else
+			{
+				w.append("<p><b>Please considder installing 'sp_BlitzLock' on the server '" + getReportingInstance().getDbmsServerName() + "', this will give more detailed information about the deadlocks in here.</b></p>");
+			}
+
+			// OTHER info
+//			if (StringUtil.hasValue(_deadlockSummaryPeriodReport_xxx))
+//			{
+//				w.append("Below are some Deadlock Information from: XXX <br>");
+//			}
+		}
+		else
+		{
+			if (_deadlockSummaryPeriodCount == 0)
+			{
+				// in GREEN
+				w.append("<p style='color:green'>Found " + _deadlockSummaryPeriodCount + " Deadlocks in the recording period...<br><br></p>");
+			}
+		}
+	}
+
+	@Override
+	public String getSubject()
+	{
+		return "Deadlock Information for the full day (origin: CmSummary,CmPerfCounters,sp_BlitzLock)";
+	}
+
+	@Override
+	public boolean hasIssueToReport()
+	{
+		return _deadlockSummaryPeriodCount > 0;
+	}
+
+
+	@Override
+	public void create(DbxConnection conn, String srvName, Configuration pcsSavedConf, Configuration localConf)
+	{
+		String schema = getReportingInstance().getDbmsSchemaName();
+
+		try 
+		{
+			// Get value from PCS KeyValue Store
+			try
+			{
+				_deadlockSummaryPeriodCount = PersistWriterJdbc.getKeyValueStoreAsInteger(conn, CounterControllerSqlServer.PCS_KEY_VALUE_deadlockCountOverRecordingPeriod, -1);
+			}
+			catch (SQLException ex)
+			{
+				_logger.warn("Problems getting Deadlock Count from 'PCS Key Value Store'.", ex);
+			}
+//System.out.println("_deadlockSummaryPeriodCount[STEP-1-KeyValStore]=" + _deadlockSummaryPeriodCount);
+			
+			// deadlock count from the "chart/graph" table
+//			String sqlGetDeadlockCount = conn.quotifySqlString("select sum([Deadlock Count]) from [CmSummary_DeadlockCountSum]"); // NEW Style
+			String sqlGetDeadlockCount = conn.quotifySqlString("select sum([data_0]) from [CmSummary_DeadlockCountSum] where [label_0] = 'Deadlock Count'"); // OLD Style
+			try (Statement stmnt = conn.createStatement(); ResultSet rs = stmnt.executeQuery(sqlGetDeadlockCount))
+			{
+				int deadlockCount = -1;
+				while(rs.next())
+					deadlockCount = rs.getInt(1);
+
+//System.out.println("_deadlockSummaryPeriodCount[KeyValStore]=" + _deadlockSummaryPeriodCount + ", deadlockCount[CmSummary_DeadlockCountSum]=" + deadlockCount);
+				_deadlockSummaryPeriodCount = deadlockCount;
+			}
+			catch (SQLException ex)
+			{
+				_logger.warn("Problems getting Deadlock Count from 'CmSummary_DeadlockCountSum' using SQL=|" + sqlGetDeadlockCount + "|", ex);
+			}
+
+			if (_deadlockSummaryPeriodCount > 0)
+			{
+				_deadlockSummaryPeriodReport_spBlitzLock = PersistWriterJdbc.getKeyValueStoreAsString(conn, CounterControllerSqlServer.PCS_KEY_VALUE_deadlockReport_blitzLock);
+//				_deadlockSummaryPeriodReport_xxx         = PersistWriterJdbc.getKeyValueStoreAsString(conn, CounterControllerSqlServer.PCS_KEY_VALUE_deadlockReport_xxx);
+
+//System.out.println("_deadlockSummaryPeriodReport_spBlitzLock=|" + _deadlockSummaryPeriodReport_spBlitzLock + "|");
+				if (StringUtil.hasValue(_deadlockSummaryPeriodReport_spBlitzLock))	
+				{
+					if (_deadlockSummaryPeriodReport_spBlitzLock.startsWith("ERROR: ErrorCode="))
+					{
+						addInfoMessage("Some error(s) was caught when calling 'sp_BlitzLock', this needs to be fixed: " + _deadlockSummaryPeriodReport_spBlitzLock);
+//TODO: Check how/where the message is printed
+					}
+					else
+					{
+//						// TODO: Decode the report(s) into ResultSetTableModel objects so we can print some HTML Tables out of it
+//						List<ResultSetTableModel> rstmList = ResultSetTableModel.parseTextTables(_deadlockSummaryPeriodReport_spBlitzLock);
+//						if (rstmList.size() >= 1) _spBlitzLock_section1 = rstmList.get(0);
+//						if (rstmList.size() >= 2) _spBlitzLock_section2 = rstmList.get(1);
+//						if (rstmList.size() >= 3) _spBlitzLock_section3 = rstmList.get(2);
+//
+//						// Guess what data types that each column holds (makes the HTML tables sortable/readable)
+//						if (_spBlitzLock_section1 != null) _spBlitzLock_section1.guessDatatypes();
+//						if (_spBlitzLock_section2 != null) _spBlitzLock_section2.guessDatatypes();
+//						if (_spBlitzLock_section3 != null) _spBlitzLock_section3.guessDatatypes();
+
+						// Decode the report(s) into ResultSetTableModel objects so we can print some HTML Tables out of it
+						List<ResultSetTableModel> rstmList = ResultSetTableModel.parseJsonMultiText(_deadlockSummaryPeriodReport_spBlitzLock);
+//System.out.println(">>>>>>>>>>>>>>>>>>>>>> rstmList.size()==" + rstmList.size());
+						if (rstmList.size() >= 1) _spBlitzLock_section1 = rstmList.get(0);
+						if (rstmList.size() >= 2) _spBlitzLock_section2 = rstmList.get(1);
+						if (rstmList.size() >= 3) _spBlitzLock_section3 = rstmList.get(2);
+					}
+				}
+				else
+				{
+					_logger.info("NO 'sp_BlitzLock' has been saved in the PCS Key Value store with key '" + CounterControllerSqlServer.PCS_KEY_VALUE_deadlockReport_blitzLock + "'.");
+					addInfoMessage("Some error(s) was caught when calling 'sp_BlitzLock', this needs to be fixed: " + _deadlockSummaryPeriodReport_spBlitzLock);
+				}
+				
+				// Get some Charts
+				_CmSummary_DeadlockCountSum     = createTsLineChart(conn, schema, "CmSummary",         "DeadlockCountSum", -1,       false, null,    "Deadlock Count (Summary)");
+				_CmPerfCounters_DeadlockDetails = createTsLineChart(conn, schema, "CmPerfCounters",    "DeadlockDetails" , -1,       false, null,    "Deadlock Count Details (Server->Perf Counters)");
+			}
+			else
+			{
+				_logger.info("No Deadlocks were found in the period. _deadlockSummaryPeriodCount=" + _deadlockSummaryPeriodCount);
+			}
+		}
+		catch (SQLException ex) 
+		{
+			_logger.error("Problems creating Deadlock Report.", ex);
+			addProblemMessage("Problems creating Deadlock Report. Caught: " + ex);
+		}		
+	}
+	
+	private int    _deadlockSummaryPeriodCount              = -1;
+	private String _deadlockSummaryPeriodReport_spBlitzLock = null;
+//	private String _deadlockSummaryPeriodReport_xxx         = null;
+
+	private ResultSetTableModel _spBlitzLock_section1 = null;
+	private ResultSetTableModel _spBlitzLock_section2 = null;
+	private ResultSetTableModel _spBlitzLock_section3 = null;
+	
+	private IReportChart _CmSummary_DeadlockCountSum;
+	private IReportChart _CmPerfCounters_DeadlockDetails;
+}

--- a/src/com/asetune/pcs/report/content/sqlserver/SqlServerQueryStore.java
+++ b/src/com/asetune/pcs/report/content/sqlserver/SqlServerQueryStore.java
@@ -278,21 +278,7 @@ extends SqlServerAbstract
 		}
 	}
 
-//	/**
-//	 * Set descriptions for the table, and the columns
-//	 */
-//	private void setSectionDescription(ResultSetTableModel rstm)
-//	{
-//		if (rstm == null)
-//			return;
-//		
-//		// Section description
-//		rstm.setDescription(
-//				"Information from last collector sample from the table <code>CmIndexMissing_abs</code><br>" +
-//				"");
-//	}
 
-	
 	//----------------------------------------------------------------------------------------------
 	//-- CLASS: QsExecutionPlanCollection
 	//----------------------------------------------------------------------------------------------
@@ -867,7 +853,8 @@ extends SqlServerAbstract
 				    + "    ,max([execution_type_desc])                                                 as [execution_type_desc] \n"
 				    + "    ,min([first_execution_time])                                                as [first_execution_time] \n"
 				    + "    ,max([last_execution_time])                                                 as [last_execution_time] \n"
-                                                                                                       
+
+				    + "    ,cast( (sum([avg_cpu_time])*1.0) / (avg([avg_dop])*1.0) / (sum([avg_duration])*1.0) * 100.0 as numeric(9,1)) as [efficiency_pct] \n"
 				    + "    ,''                                                                         as [count_executions__chart] \n"
 				    + "    ,sum([count_executions])                                                    as [count_executions__sum] \n"
 
@@ -1550,8 +1537,160 @@ extends SqlServerAbstract
 		}
 		
 
+//		/**
+//		 * Set CPU column descriptions
+//		 */
+//		protected void setCpuSectionDescription(ResultSetTableModel rstm)
+//		{
+//			if (rstm == null)
+//				return;
+//			
+//			// Section description
+//			rstm.setDescription("<b>&bull; Top CPU</b> (ordered by: total_cpu_time)");
+//
+//			// Columns description
+//			rstm.setColumnDescription("runtime_stats_id"                 , "Identifier of the row representing runtime execution statistics for the plan_id, execution_type and runtime_stats_interval_id. It is unique only for the past runtime statistics intervals. For currently active interval there may be multiple rows representing runtime statistics for the plan referenced by plan_id, with the execution type represented by execution_type. Typically, one row represents runtime statistics that are flushed to disk, while other(s) represent in-memory state. Hence, to get actual state for every interval you need to aggregate metrics, grouping by plan_id, execution_type and runtime_stats_interval_id.");
+//			rstm.setColumnDescription("plan_id"                          , "Foreign key. Joins to sys.query_store_plan (Transact-SQL).");
+//			rstm.setColumnDescription("runtime_stats_interval_id"        , "Foreign key. Joins to sys.query_store_runtime_stats_interval (Transact-SQL).");
+//			rstm.setColumnDescription("execution_type"                   , "Determines type of query execution: 0 - Regular execution (successfully finished); 3 - Client initiated aborted execution; 4 - Exception aborted execution;");
+//			rstm.setColumnDescription("execution_type_desc"              , "Textual description of the execution type field: 0 - Regular; 3 - Aborted; 4 - Exception;");
+//			rstm.setColumnDescription("first_execution_time"             , "First execution time for the query plan within the aggregation interval. This refers to the end time of the query execution.");
+//			rstm.setColumnDescription("last_execution_time"              , "Last execution time for the query plan within the aggregation interval. This refers to the end time of the query execution.");
+//			
+//			rstm.setColumnDescription("count_executions"                 , "Total count of executions for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("count_executions__sum"            , "Summary of: Total count of executions for the query plan within the recording period (usually 24 hours).");
+//			rstm.setColumnDescription("count_executions__chart"          , "Chart of:   Total count of executions for the query plan within the aggregation interval.");
+//                                                                         
+//			rstm.setColumnDescription("avg_duration_ms__sum"             , "Summary of: Average duration for the query plan within the recording period (usually 24 hours) (reported in milliseconds) .");
+//			rstm.setColumnDescription("avg_duration__sum"                , "Summary of: Average duration for the query plan within the recording period (usually 24 hours) (reported in microseconds) .");
+//			rstm.setColumnDescription("avg_duration__chart"              , "Chart of:   Average duration for the query plan within the aggregation interval (reported in microseconds) .");
+//			rstm.setColumnDescription("avg_duration"                     , "Average duration for the query plan within the aggregation interval (reported in microseconds) .");
+//			rstm.setColumnDescription("last_duration"                    , "Last duration for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("min_duration"                     , "Minimum duration for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("max_duration"                     , "Maximum duration for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("stdev_duration"                   , "Duration standard deviation for the query plan within the aggregation interval (reported in microseconds).");
+//                                                                         
+//			rstm.setColumnDescription("avg_cpu_time_ms__sum"             , "Summary of: Average CPU time for the query plan within the recording period (usually 24 hours) (reported in milliseconds).");
+//			rstm.setColumnDescription("avg_cpu_time__sum"                , "Summary of: Average CPU time for the query plan within the recording period (usually 24 hours) (reported in microseconds).");
+//			rstm.setColumnDescription("avg_cpu_time__chart"              , "Chart of:   Average CPU time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("avg_cpu_time"                     , "Average CPU time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("last_cpu_time"                    , "Last CPU time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("min_cpu_time"                     , "Minimum CPU time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("max_cpu_time"                     , "Maximum CPU time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("stdev_cpu_time"                   , "CPU time standard deviation for the query plan within the aggregation interval (reported in microseconds).");
+//                                                                         
+//			rstm.setColumnDescription("avg_logical_io_reads__sum"        , "Summary of: Average number of logical I/O reads for the query plan within the recording period (usually 24 hours). (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("avg_logical_io_reads__chart"      , "Chart of:   Average number of logical I/O reads for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("avg_logical_io_reads"             , "Average number of logical I/O reads for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("last_logical_io_reads"            , "Last number of logical I/O reads for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("min_logical_io_reads"             , "Minimum number of logical I/O reads for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("max_logical_io_reads"             , "Maximum number of logical I/O reads for the query plan within the aggregation interval.(expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("stdev_logical_io_reads"           , "Number of logical I/O reads standard deviation for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
+//			                                                             
+//			rstm.setColumnDescription("avg_logical_io_writes__sum"       , "Summary of: Average number of logical I/O writes for the query plan within the recording period (usually 24 hours).");
+//			rstm.setColumnDescription("avg_logical_io_writes__chart"     , "Chart of:   Average number of logical I/O writes for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("avg_logical_io_writes"            , "Average number of logical I/O writes for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("last_logical_io_writes"           , "Last number of logical I/O writes for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("min_logical_io_writes"            , "Minimum number of logical I/O writes for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("max_logical_io_writes"            , "Maximum number of logical I/O writes for the query plan within the aggregation interval");
+//			rstm.setColumnDescription("stdev_logical_io_writes"          , "Number of logical I/O writes standard deviation for the query plan within the aggregation interval.");
+//			                                                             
+//			rstm.setColumnDescription("avg_physical_io_reads__sum"       , "Summary of: Average number of physical I/O reads for the query plan within the recording period (usually 24 hours) (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("avg_physical_io_reads__chart"     , "Chart of:   Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("avg_physical_io_reads"            , "Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("last_physical_io_reads"           , "Last number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("min_physical_io_reads"            , "Minimum number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("max_physical_io_reads"            , "Maximum number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("stdev_physical_io_reads"          , "Number of physical I/O reads standard deviation for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			                                                             
+//			rstm.setColumnDescription("avg_clr_time_ms__sum"             , "Summary of: Average CLR time for the query plan within the recording period (usually 24 hours) (reported in milliseconds).");
+//			rstm.setColumnDescription("avg_clr_time__sum"                , "Summary of: Average CLR time for the query plan within the recording period (usually 24 hours) (reported in microseconds).");
+//			rstm.setColumnDescription("avg_clr_time__chart"              , "Chart of:   Average CLR time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("avg_clr_time"                     , "Average CLR time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("last_clr_time"                    , "Last CLR time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("min_clr_time"                     , "Minimum CLR time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("max_clr_time"                     , "Maximum CLR time for the query plan within the aggregation interval (reported in microseconds).");
+//			rstm.setColumnDescription("stdev_clr_time"                   , "CLR time standard deviation for the query plan within the aggregation interval (reported in microseconds).");
+//			                                                             
+//			rstm.setColumnDescription("avg_dop__avg"                     , "Average of: Average DOP (degree of parallelism) for the query plan within the recording period (usually 24 hours).");
+//			rstm.setColumnDescription("avg_dop__sum"                     , "Summary of: Average DOP (degree of parallelism) for the query plan within the recording period (usually 24 hours).");
+//			rstm.setColumnDescription("avg_dop__chart"                   , "Chart of:   Average DOP (degree of parallelism) for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("avg_dop"                          , "Average DOP (degree of parallelism) for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("last_dop"                         , "Last DOP (degree of parallelism) for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("min_dop"                          , "Minimum DOP (degree of parallelism) for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("max_dop"                          , "Maximum DOP (degree of parallelism) for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("stdev_dop"                        , "DOP (degree of parallelism) standard deviation for the query plan within the aggregation interval.");
+//			
+//			rstm.setColumnDescription("avg_query_max_used_memory__sum"   , "Summary of: Average memory grant (reported as the number of 8 KB pages) for the query plan within the recording period (usually 24 hours). Always 0 for queries using natively compiled memory optimized procedures.");
+//			rstm.setColumnDescription("avg_query_max_used_memory__chart" , "Chart of:   Average memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+//			rstm.setColumnDescription("avg_query_max_used_memory"        , "Average memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+//			rstm.setColumnDescription("last_query_max_used_memory"       , "Last memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+//			rstm.setColumnDescription("min_query_max_used_memory"        , "Minimum memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+//			rstm.setColumnDescription("max_query_max_used_memory"        , "Maximum memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+//			rstm.setColumnDescription("stdev_query_max_used_memory"      , "Memory grant standard deviation (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+//			
+//			rstm.setColumnDescription("avg_rowcount__sum"                , "Summary of: Average number of returned rows for the query plan within the recording period (usually 24 hours).");
+//			rstm.setColumnDescription("avg_rowcount__chart"              , "Chart of:   Average number of returned rows for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("avg_rowcount"                     , "Average number of returned rows for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("last_rowcount"                    , "Number of returned rows by the last execution of the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("min_rowcount"                     , "Minimum number of returned rows for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("max_rowcount"                     , "Maximum number of returned rows for the query plan within the aggregation interval.");
+//			rstm.setColumnDescription("stdev_rowcount"                   , "Number of returned rows standard deviation for the query plan within the aggregation interval.");
+//			
+//			rstm.setColumnDescription("avg_num_physical_io_reads__sum"   , "Summary of: Average number of physical I/O reads for the query plan within the recording period (usually 24 hours) (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("avg_num_physical_io_reads__chart" , "Chart of:   Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("avg_num_physical_io_reads"        , "Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("last_num_physical_io_reads"       , "Last number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("min_num_physical_io_reads"        , "Minimum number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("max_num_physical_io_reads"        , "Maximum number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("stdev_num_physical_io_reads"      , "Number of physical I/O reads standard deviation for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			
+//			rstm.setColumnDescription("avg_log_bytes_used__sum"          , "Summary of: Average number of bytes in the database log used by the query plan, wirecording period interval (usually 24 hours).");
+//			rstm.setColumnDescription("avg_log_bytes_used__chart"        , "Chart of:   Average number of bytes in the database log used by the query plan, within the aggregation interval.");
+//			rstm.setColumnDescription("avg_log_bytes_used"               , "Average number of bytes in the database log used by the query plan, within the aggregation interval.");
+//			rstm.setColumnDescription("last_log_bytes_used"              , "Number of bytes in the database log used by the last execution of the query plan, within the aggregation interval.");
+//			rstm.setColumnDescription("min_log_bytes_used"               , "Minimum number of bytes in the database log used by the query plan, within the aggregation interval.");
+//			rstm.setColumnDescription("max_log_bytes_used"               , "Maximum number of bytes in the database log used by the query plan, within the aggregation interval.");
+//			rstm.setColumnDescription("stdev_log_bytes_used"             , "Standard deviation of the number of bytes in the database log used by a query plan, within the aggregation interval.");
+//			
+//			rstm.setColumnDescription("avg_tempdb_space_used__sum"       , "Summary of: Average number of pages used in tempdb for the query plan within the recording period (usually 24 hours) (expressed as a number of 8KB pages).");
+//			rstm.setColumnDescription("avg_tempdb_space_used__chart"     , "Chart of:   Average number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
+//			rstm.setColumnDescription("avg_tempdb_space_used"            , "Average number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
+//			rstm.setColumnDescription("last_tempdb_space_used"           , "Last number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
+//			rstm.setColumnDescription("min_tempdb_space_used"            , "Minimum number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
+//			rstm.setColumnDescription("max_tempdb_space_used"            , "Maximum number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
+//			rstm.setColumnDescription("stdev_tempdb_space_used"          , "Number of pages used in tempdb standard deviation for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
+//			
+//			rstm.setColumnDescription("avg_page_server_io_reads__sum"    , "Summary of: Average number of page server I/O reads for the query plan within the recording period (usually 24 hours) (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("avg_page_server_io_reads__chart"  , "Chart of:   Average number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("avg_page_server_io_reads"         , "Average number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("last_page_server_io_reads"        , "Last number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("min_page_server_io_reads"         , "Minimum number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("max_page_server_io_reads"         , "Maximum number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("stdev_page_server_io_reads"       , "Number of page server I/O reads standard deviation for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
+//			
+//
+//			rstm.setColumnDescription("total_duration_ms__sum"           , "Total duration for the query plan (reported in milliseconds).");
+//			rstm.setColumnDescription("total_duration__sum"              , "Total duration for the query plan (reported in microseconds).");
+//			rstm.setColumnDescription("total_cpu_time_ms__sum"           , "Total CPU time for the query plan (reported in milliseconds).");
+//			rstm.setColumnDescription("total_cpu_time__sum"              , "Total CPU time for the query plan (reported in microseconds).");
+//			rstm.setColumnDescription("total_logical_io_reads__sum"      , "Total number of logical I/O reads for the query plan. (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("total_logical_io_writes__sum"     , "Total number of logical I/O writes for the query plan.");
+//			rstm.setColumnDescription("total_physical_io_reads__sum"     , "Total number of physical I/O reads for the query plan (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("total_clr_time_ms__sum"           , "Total CLR time for the query plan (reported in milliseconds).");
+//			rstm.setColumnDescription("total_clr_time__sum"              , "Total CLR time for the query plan (reported in microseconds).");
+//			rstm.setColumnDescription("total_dop__sum"                   , "Total DOP (degree of parallelism) for the query plan.");
+//			rstm.setColumnDescription("total_query_max_used_memory__sum" , "Total memory grant (reported as the number of 8 KB pages) for the query plan. Always 0 for queries using natively compiled memory optimized procedures.");
+//			rstm.setColumnDescription("total_rowcount__sum"              , "Total number of returned rows for the query plan.");
+//			rstm.setColumnDescription("total_num_physical_io_reads__sum" , "Total number of physical I/O reads for the query plan (expressed as a number of 8KB pages read).");
+//			rstm.setColumnDescription("total_log_bytes_used__sum"        , "Total number of bytes in the database log used by the query plan.");
+//			rstm.setColumnDescription("total_tempdb_space_used__sum"     , "Total number of pages used in tempdb for the query plan (expressed as a number of 8KB pages).");
+//			rstm.setColumnDescription("total_page_server_io_reads__sum"  , "Total number of page server I/O reads for the query plan (expressed as a number of 8KB pages read).");
+//		
+//		}
+
 		/**
-		 * Set CPU column descriptions
+		 * Set descriptions for the table, and the columns
 		 */
 		protected void setCpuSectionDescription(ResultSetTableModel rstm)
 		{
@@ -1559,149 +1698,109 @@ extends SqlServerAbstract
 				return;
 			
 			// Section description
-			rstm.setDescription("<b>&bull; Top CPU</b> (ordered by: total_cpu_time)");
-
+			rstm.setDescription(
+					"Information from the Query Store table <code>query_store_runtime_stats</code> and for wait columns table <code>query_store_wait_stats</code><br>" +
+					"");
+			
 			// Columns description
-			rstm.setColumnDescription("runtime_stats_id"                 , "Identifier of the row representing runtime execution statistics for the plan_id, execution_type and runtime_stats_interval_id. It is unique only for the past runtime statistics intervals. For currently active interval there may be multiple rows representing runtime statistics for the plan referenced by plan_id, with the execution type represented by execution_type. Typically, one row represents runtime statistics that are flushed to disk, while other(s) represent in-memory state. Hence, to get actual state for every interval you need to aggregate metrics, grouping by plan_id, execution_type and runtime_stats_interval_id.");
-			rstm.setColumnDescription("plan_id"                          , "Foreign key. Joins to sys.query_store_plan (Transact-SQL).");
-			rstm.setColumnDescription("runtime_stats_interval_id"        , "Foreign key. Joins to sys.query_store_runtime_stats_interval (Transact-SQL).");
-			rstm.setColumnDescription("execution_type"                   , "Determines type of query execution: 0 - Regular execution (successfully finished); 3 - Client initiated aborted execution; 4 - Exception aborted execution;");
-			rstm.setColumnDescription("execution_type_desc"              , "Textual description of the execution type field: 0 - Regular; 3 - Aborted; 4 - Exception;");
-			rstm.setColumnDescription("first_execution_time"             , "First execution time for the query plan within the aggregation interval. This refers to the end time of the query execution.");
-			rstm.setColumnDescription("last_execution_time"              , "Last execution time for the query plan within the aggregation interval. This refers to the end time of the query execution.");
-			
-			rstm.setColumnDescription("count_executions"                 , "Total count of executions for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("count_executions__sum"            , "Summary of: Total count of executions for the query plan within the recording period (usually 24 hours).");
-			rstm.setColumnDescription("count_executions__chart"          , "Chart of:   Total count of executions for the query plan within the aggregation interval.");
-                                                                         
-			rstm.setColumnDescription("avg_duration_ms__sum"             , "Summary of: Average duration for the query plan within the recording period (usually 24 hours) (reported in milliseconds) .");
-			rstm.setColumnDescription("avg_duration__sum"                , "Summary of: Average duration for the query plan within the recording period (usually 24 hours) (reported in microseconds) .");
-			rstm.setColumnDescription("avg_duration__chart"              , "Chart of:   Average duration for the query plan within the aggregation interval (reported in microseconds) .");
-			rstm.setColumnDescription("avg_duration"                     , "Average duration for the query plan within the aggregation interval (reported in microseconds) .");
-			rstm.setColumnDescription("last_duration"                    , "Last duration for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("min_duration"                     , "Minimum duration for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("max_duration"                     , "Maximum duration for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("stdev_duration"                   , "Duration standard deviation for the query plan within the aggregation interval (reported in microseconds).");
-                                                                         
-			rstm.setColumnDescription("avg_cpu_time_ms__sum"             , "Summary of: Average CPU time for the query plan within the recording period (usually 24 hours) (reported in milliseconds).");
-			rstm.setColumnDescription("avg_cpu_time__sum"                , "Summary of: Average CPU time for the query plan within the recording period (usually 24 hours) (reported in microseconds).");
-			rstm.setColumnDescription("avg_cpu_time__chart"              , "Chart of:   Average CPU time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("avg_cpu_time"                     , "Average CPU time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("last_cpu_time"                    , "Last CPU time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("min_cpu_time"                     , "Minimum CPU time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("max_cpu_time"                     , "Maximum CPU time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("stdev_cpu_time"                   , "CPU time standard deviation for the query plan within the aggregation interval (reported in microseconds).");
-                                                                         
-			rstm.setColumnDescription("avg_logical_io_reads__sum"        , "Summary of: Average number of logical I/O reads for the query plan within the recording period (usually 24 hours). (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("avg_logical_io_reads__chart"      , "Chart of:   Average number of logical I/O reads for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("avg_logical_io_reads"             , "Average number of logical I/O reads for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("last_logical_io_reads"            , "Last number of logical I/O reads for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("min_logical_io_reads"             , "Minimum number of logical I/O reads for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("max_logical_io_reads"             , "Maximum number of logical I/O reads for the query plan within the aggregation interval.(expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("stdev_logical_io_reads"           , "Number of logical I/O reads standard deviation for the query plan within the aggregation interval. (expressed as a number of 8KB pages read).");
-			                                                             
-			rstm.setColumnDescription("avg_logical_io_writes__sum"       , "Summary of: Average number of logical I/O writes for the query plan within the recording period (usually 24 hours).");
-			rstm.setColumnDescription("avg_logical_io_writes__chart"     , "Chart of:   Average number of logical I/O writes for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("avg_logical_io_writes"            , "Average number of logical I/O writes for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("last_logical_io_writes"           , "Last number of logical I/O writes for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("min_logical_io_writes"            , "Minimum number of logical I/O writes for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("max_logical_io_writes"            , "Maximum number of logical I/O writes for the query plan within the aggregation interval");
-			rstm.setColumnDescription("stdev_logical_io_writes"          , "Number of logical I/O writes standard deviation for the query plan within the aggregation interval.");
-			                                                             
-			rstm.setColumnDescription("avg_physical_io_reads__sum"       , "Summary of: Average number of physical I/O reads for the query plan within the recording period (usually 24 hours) (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("avg_physical_io_reads__chart"     , "Chart of:   Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("avg_physical_io_reads"            , "Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("last_physical_io_reads"           , "Last number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("min_physical_io_reads"            , "Minimum number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("max_physical_io_reads"            , "Maximum number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("stdev_physical_io_reads"          , "Number of physical I/O reads standard deviation for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			                                                             
-			rstm.setColumnDescription("avg_clr_time_ms__sum"             , "Summary of: Average CLR time for the query plan within the recording period (usually 24 hours) (reported in milliseconds).");
-			rstm.setColumnDescription("avg_clr_time__sum"                , "Summary of: Average CLR time for the query plan within the recording period (usually 24 hours) (reported in microseconds).");
-			rstm.setColumnDescription("avg_clr_time__chart"              , "Chart of:   Average CLR time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("avg_clr_time"                     , "Average CLR time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("last_clr_time"                    , "Last CLR time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("min_clr_time"                     , "Minimum CLR time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("max_clr_time"                     , "Maximum CLR time for the query plan within the aggregation interval (reported in microseconds).");
-			rstm.setColumnDescription("stdev_clr_time"                   , "CLR time standard deviation for the query plan within the aggregation interval (reported in microseconds).");
-			                                                             
-			rstm.setColumnDescription("avg_dop__avg"                     , "Average of: Average DOP (degree of parallelism) for the query plan within the recording period (usually 24 hours).");
-			rstm.setColumnDescription("avg_dop__sum"                     , "Summary of: Average DOP (degree of parallelism) for the query plan within the recording period (usually 24 hours).");
-			rstm.setColumnDescription("avg_dop__chart"                   , "Chart of:   Average DOP (degree of parallelism) for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("avg_dop"                          , "Average DOP (degree of parallelism) for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("last_dop"                         , "Last DOP (degree of parallelism) for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("min_dop"                          , "Minimum DOP (degree of parallelism) for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("max_dop"                          , "Maximum DOP (degree of parallelism) for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("stdev_dop"                        , "DOP (degree of parallelism) standard deviation for the query plan within the aggregation interval.");
-			
-			rstm.setColumnDescription("avg_query_max_used_memory__sum"   , "Summary of: Average memory grant (reported as the number of 8 KB pages) for the query plan within the recording period (usually 24 hours). Always 0 for queries using natively compiled memory optimized procedures.");
-			rstm.setColumnDescription("avg_query_max_used_memory__chart" , "Chart of:   Average memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
-			rstm.setColumnDescription("avg_query_max_used_memory"        , "Average memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
-			rstm.setColumnDescription("last_query_max_used_memory"       , "Last memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
-			rstm.setColumnDescription("min_query_max_used_memory"        , "Minimum memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
-			rstm.setColumnDescription("max_query_max_used_memory"        , "Maximum memory grant (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
-			rstm.setColumnDescription("stdev_query_max_used_memory"      , "Memory grant standard deviation (reported as the number of 8 KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
-			
-			rstm.setColumnDescription("avg_rowcount__sum"                , "Summary of: Average number of returned rows for the query plan within the recording period (usually 24 hours).");
-			rstm.setColumnDescription("avg_rowcount__chart"              , "Chart of:   Average number of returned rows for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("avg_rowcount"                     , "Average number of returned rows for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("last_rowcount"                    , "Number of returned rows by the last execution of the query plan within the aggregation interval.");
-			rstm.setColumnDescription("min_rowcount"                     , "Minimum number of returned rows for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("max_rowcount"                     , "Maximum number of returned rows for the query plan within the aggregation interval.");
-			rstm.setColumnDescription("stdev_rowcount"                   , "Number of returned rows standard deviation for the query plan within the aggregation interval.");
-			
-			rstm.setColumnDescription("avg_num_physical_io_reads__sum"   , "Summary of: Average number of physical I/O reads for the query plan within the recording period (usually 24 hours) (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("avg_num_physical_io_reads__chart" , "Chart of:   Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("avg_num_physical_io_reads"        , "Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("last_num_physical_io_reads"       , "Last number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("min_num_physical_io_reads"        , "Minimum number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("max_num_physical_io_reads"        , "Maximum number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("stdev_num_physical_io_reads"      , "Number of physical I/O reads standard deviation for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			
-			rstm.setColumnDescription("avg_log_bytes_used__sum"          , "Summary of: Average number of bytes in the database log used by the query plan, wirecording period interval (usually 24 hours).");
-			rstm.setColumnDescription("avg_log_bytes_used__chart"        , "Chart of:   Average number of bytes in the database log used by the query plan, within the aggregation interval.");
-			rstm.setColumnDescription("avg_log_bytes_used"               , "Average number of bytes in the database log used by the query plan, within the aggregation interval.");
-			rstm.setColumnDescription("last_log_bytes_used"              , "Number of bytes in the database log used by the last execution of the query plan, within the aggregation interval.");
-			rstm.setColumnDescription("min_log_bytes_used"               , "Minimum number of bytes in the database log used by the query plan, within the aggregation interval.");
-			rstm.setColumnDescription("max_log_bytes_used"               , "Maximum number of bytes in the database log used by the query plan, within the aggregation interval.");
-			rstm.setColumnDescription("stdev_log_bytes_used"             , "Standard deviation of the number of bytes in the database log used by a query plan, within the aggregation interval.");
-			
-			rstm.setColumnDescription("avg_tempdb_space_used__sum"       , "Summary of: Average number of pages used in tempdb for the query plan within the recording period (usually 24 hours) (expressed as a number of 8KB pages).");
-			rstm.setColumnDescription("avg_tempdb_space_used__chart"     , "Chart of:   Average number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
-			rstm.setColumnDescription("avg_tempdb_space_used"            , "Average number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
-			rstm.setColumnDescription("last_tempdb_space_used"           , "Last number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
-			rstm.setColumnDescription("min_tempdb_space_used"            , "Minimum number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
-			rstm.setColumnDescription("max_tempdb_space_used"            , "Maximum number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
-			rstm.setColumnDescription("stdev_tempdb_space_used"          , "Number of pages used in tempdb standard deviation for the query plan within the aggregation interval (expressed as a number of 8KB pages).");
-			
-			rstm.setColumnDescription("avg_page_server_io_reads__sum"    , "Summary of: Average number of page server I/O reads for the query plan within the recording period (usually 24 hours) (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("avg_page_server_io_reads__chart"  , "Chart of:   Average number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("avg_page_server_io_reads"         , "Average number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("last_page_server_io_reads"        , "Last number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("min_page_server_io_reads"         , "Minimum number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("max_page_server_io_reads"         , "Maximum number of page server I/O reads for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("stdev_page_server_io_reads"       , "Number of page server I/O reads standard deviation for the query plan within the aggregation interval (expressed as a number of 8KB pages read).");
-			
+			rstm.setColumnDescription("dbname"                                , "Name of the database");
+			rstm.setColumnDescription("plan_id"                               , "Foreign key. Joins to sys.query_store_plan");
+			rstm.setColumnDescription("plan_text"                             , "Click on the below number to show the query plan.");
+			rstm.setColumnDescription("txt"                                   , "SQL Text (hover over the icon or click it)");
+			rstm.setColumnDescription("wait"                                  , "Wait Information (hover over the icon or click it)");
+			rstm.setColumnDescription("execution_type"                        , "Determines type of query execution: \n" + 
+			                                                                    "0 - Regular execution (successfully finished) \n" +
+			                                                                    "3 - Client initiated aborted execution \n" +
+			                                                                    "4 - Exception aborted execution \n");
+			rstm.setColumnDescription("execution_type_desc"                   , "Textual description of the execution type field: \n" +
+			                                                                    "0 - Regular \n" +
+			                                                                    "3 - Aborted \n" + 
+			                                                                    "4 - Exception \n");
+			rstm.setColumnDescription("first_execution_time"                  , "First execution time for the query plan within the aggregation interval. This is the end time of the query execution.");
+			rstm.setColumnDescription("last_execution_time"                   , "Last execution time for the query plan within the aggregation interval. This is the end time of the query execution.");
+			rstm.setColumnDescription("efficiency_pct"                        , "How efficient is the statement. \n" +
+			                                                                    "This is a percentage calculation of how well we have used the CPU for this statement... or more precise: 'sum(avg_cpu_time)' / 'avg(avg_dop)' / 'sum(avg_duration)' * 100.0 \n" +
+			                                                                    "The lower percentage, the more 'waitTime' we have. (it can be physical IO, blocking locks, Waiting to be sceduled or similar) \n" + 
+			                                                                    "And if it's a parallel query, where the DOP might be skewed (work is not evenly distributed over the worker threads), the percent will be 'lower'...");
 
-			rstm.setColumnDescription("total_duration_ms__sum"           , "Total duration for the query plan (reported in milliseconds).");
-			rstm.setColumnDescription("total_duration__sum"              , "Total duration for the query plan (reported in microseconds).");
-			rstm.setColumnDescription("total_cpu_time_ms__sum"           , "Total CPU time for the query plan (reported in milliseconds).");
-			rstm.setColumnDescription("total_cpu_time__sum"              , "Total CPU time for the query plan (reported in microseconds).");
-			rstm.setColumnDescription("total_logical_io_reads__sum"      , "Total number of logical I/O reads for the query plan. (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("total_logical_io_writes__sum"     , "Total number of logical I/O writes for the query plan.");
-			rstm.setColumnDescription("total_physical_io_reads__sum"     , "Total number of physical I/O reads for the query plan (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("total_clr_time_ms__sum"           , "Total CLR time for the query plan (reported in milliseconds).");
-			rstm.setColumnDescription("total_clr_time__sum"              , "Total CLR time for the query plan (reported in microseconds).");
-			rstm.setColumnDescription("total_dop__sum"                   , "Total DOP (degree of parallelism) for the query plan.");
-			rstm.setColumnDescription("total_query_max_used_memory__sum" , "Total memory grant (reported as the number of 8 KB pages) for the query plan. Always 0 for queries using natively compiled memory optimized procedures.");
-			rstm.setColumnDescription("total_rowcount__sum"              , "Total number of returned rows for the query plan.");
-			rstm.setColumnDescription("total_num_physical_io_reads__sum" , "Total number of physical I/O reads for the query plan (expressed as a number of 8KB pages read).");
-			rstm.setColumnDescription("total_log_bytes_used__sum"        , "Total number of bytes in the database log used by the query plan.");
-			rstm.setColumnDescription("total_tempdb_space_used__sum"     , "Total number of pages used in tempdb for the query plan (expressed as a number of 8KB pages).");
-			rstm.setColumnDescription("total_page_server_io_reads__sum"  , "Total number of page server I/O reads for the query plan (expressed as a number of 8KB pages read).");
-		
+			rstm.setColumnDescription("count_executions__chart"               , "Chart showing 'execution count' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("count_executions__sum"                 , "Total count of executions for the query plan within the aggregation interval.");
+
+			rstm.setColumnDescription("avg_duration__chart"                   , "Chart showing 'avg_duration' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_duration_ms__sum"                , "Total duration for the query plan within the aggregation interval");
+			rstm.setColumnDescription("avg_duration_ms__sum"                  , "Average duration for the query plan within the aggregation interval");
+
+			rstm.setColumnDescription("avg_cpu_time__chart"                   , "Chart showing 'avg_cpu_time_ms' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_cpu_time_ms__sum"                , "Total CPU time for the query plan within the aggregation interval");
+			rstm.setColumnDescription("avg_cpu_time_ms__sum"                  , "Average CPU time for the query plan within the aggregation interval");
+			
+			rstm.setColumnDescription("avg_query_wait_time_ms__chart"         , "Chart showing 'avg_query_wait_time_ms' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_query_wait_time_ms__sum"         , "Total   wait time for the query plan within the aggregation interval and wait category (reported in milliseconds)");
+			rstm.setColumnDescription("avg_query_wait_time_ms__sum"           , "Average wait duration for the query plan per execution within the aggregation interval and wait category (reported in milliseconds).");
+			
+			rstm.setColumnDescription("avg_query_wait_time_other_ms__chart"   , "Chart showing 'avg_query_wait_time_other_ms' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_query_wait_time_other_ms__sum"   , "Total   OTHER (everything but parallel) wait time for the query plan within the aggregation interval and wait category (reported in milliseconds)");
+			rstm.setColumnDescription("avg_query_wait_time_other_ms__sum"     , "Average OTHER (everything but parallel) wait duration for the query plan per execution within the aggregation interval and wait category (reported in milliseconds).");
+			
+			rstm.setColumnDescription("avg_query_wait_time_paralell_ms__chart", "Chart showing 'avg_query_wait_time_paralell_ms' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_query_wait_time_paralell_ms__sum", "Total   PARALLEL wait time for the query plan within the aggregation interval and wait category (reported in milliseconds)");
+			rstm.setColumnDescription("avg_query_wait_time_paralell_ms__sum"  , "Average PARALLEL wait duration for the query plan per execution within the aggregation interval and wait category (reported in milliseconds).");
+			
+			rstm.setColumnDescription("avg_logical_io_reads__chart"           , "Chart showing 'avg_logical_io_reads' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_logical_io_reads__sum"           , "Total number of logical I/O reads for the query plan within the aggregation interval (expressed as a number of 8-KB pages read).");
+			rstm.setColumnDescription("avg_logical_io_reads__sum"             , "Average number of logical I/O reads for the query plan within the aggregation interval (expressed as a number of 8-KB pages read).");
+			
+			rstm.setColumnDescription("avg_logical_io_reads_mb__chart"        , "Chart showing 'avg_logical_io_reads_mb' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_logical_io_reads_mb__sum"        , "Total number of logical I/O reads for the query plan within the aggregation interval (expressed as a MB or number of 8-KB pages / 128.0 read).");
+			rstm.setColumnDescription("avg_logical_io_reads_mb__sum"          , "Average number of logical I/O reads for the query plan within the aggregation interval (expressed as MB or a number of 8-KB pages / 128.0 read).");
+			
+			rstm.setColumnDescription("avg_logical_io_writes__chart"          , "Chart showing 'avg_logical_io_writes' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_logical_io_writes__sum"          , "Total number of logical I/O writes for the query plan within the aggregation interval (expressed as a number of 8-KB pages written)");
+			rstm.setColumnDescription("avg_logical_io_writes__sum"            , "Average number of logical I/O writes for the query plan within the aggregation interval (expressed as a number of 8-KB pages written)");
+			
+			rstm.setColumnDescription("avg_physical_io_reads__chart"          , "Chart showing 'avg_physical_io_reads' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_physical_io_reads__sum"          , "Total number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8-KB pages read).");
+			rstm.setColumnDescription("avg_physical_io_reads__sum"            , "Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of 8-KB pages read).");
+			
+			rstm.setColumnDescription("avg_clr_time__chart"                   , "Chart showing 'avg_clr_time_ms' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_clr_time_ms__sum"                , "Total CLR time for the query plan within the aggregation interval");
+			rstm.setColumnDescription("avg_clr_time_ms__sum"                  , "Average CLR time for the query plan within the aggregation interval");
+			
+			rstm.setColumnDescription("avg_dop__chart"                        , "Chart showing 'avg_dop' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("avg_dop__avg"                          , "Average DOP (degree of parallelism) for the query plan within the aggregation interval.");
+			
+			rstm.setColumnDescription("avg_query_max_used_memory__chart"      , "Chart showing 'avg_query_max_used_memory' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_query_max_used_memory__sum"      , "Total   memory grant (reported as the number of 8-KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+			rstm.setColumnDescription("total_query_max_used_memory_mb__sum"   , "Total   memory grant (reported as MB                      ) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+			rstm.setColumnDescription("avg_query_max_used_memory__sum"        , "Average memory grant (reported as the number of 8-KB pages) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+			rstm.setColumnDescription("avg_query_max_used_memory_mb__sum"     , "Average memory grant (reported as MB                      ) for the query plan within the aggregation interval. Always 0 for queries using natively compiled memory optimized procedures.");
+			
+			rstm.setColumnDescription("avg_rowcount__chart"                   , "Chart showing 'avg_rowcount' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_rowcount__sum"                   , "Total number of returned rows for the query plan within the aggregation interval");
+			rstm.setColumnDescription("avg_rowcount__sum"                     , "Average number of returned rows for the query plan within the aggregation interval");
+			
+			rstm.setColumnDescription("avg_num_physical_io_reads__chart"      , "Chart showing 'avg_num_physical_io_reads' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_num_physical_io_reads__sum"      , "Total number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of read I/O operations).");
+			rstm.setColumnDescription("avg_num_physical_io_reads__sum"        , "Average number of physical I/O reads for the query plan within the aggregation interval (expressed as a number of read I/O operations).");
+			
+			rstm.setColumnDescription("avg_log_bytes_used__chart"             , "Chart showing 'avg_log_bytes_used' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_log_bytes_used__sum"             , "Total   number of bytes in the database log used by the query plan, within the aggregation interval.");
+			rstm.setColumnDescription("total_log_bytes_used_kb__sum"          , "Total   number of KB    in the database log used by the query plan, within the aggregation interval.");
+			rstm.setColumnDescription("total_log_bytes_used_mb__sum"          , "Total   number of MB    in the database log used by the query plan, within the aggregation interval.");
+			rstm.setColumnDescription("avg_log_bytes_used__sum"               , "Average number of bytes in the database log used by the query plan, within the aggregation interval.");
+			rstm.setColumnDescription("avg_log_bytes_used_kb__sum"            , "Average number of KB    in the database log used by the query plan, within the aggregation interval.");
+			rstm.setColumnDescription("avg_log_bytes_used_mb__sum"            , "Average number of MB    in the database log used by the query plan, within the aggregation interval.");
+			
+			rstm.setColumnDescription("avg_tempdb_space_used__char"           , "Chart showing 'avg_tempdb_space_used' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+			rstm.setColumnDescription("total_tempdb_space_used__sum"          , "Total   number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8-KB pages).");
+			rstm.setColumnDescription("total_tempdb_space_used_kb__sum"       , "Total   number of KB    used in tempdb for the query plan within the aggregation interval (expressed as KB).");
+			rstm.setColumnDescription("total_tempdb_space_used_mb__sum"       , "Total   number of MB    used in tempdb for the query plan within the aggregation interval (expressed as MB).");
+			rstm.setColumnDescription("avg_tempdb_space_used__sum"            , "Average number of pages used in tempdb for the query plan within the aggregation interval (expressed as a number of 8-KB pages).");
+			rstm.setColumnDescription("avg_tempdb_space_used_kb__sum"         , "Average number of KB    used in tempdb for the query plan within the aggregation interval (expressed as KB).");
+			rstm.setColumnDescription("avg_tempdb_space_used_mb__sum"         , "Average number of MB    used in tempdb for the query plan within the aggregation interval (expressed as MB).");
 		}
 
+		
 		/**
 		 * Set WAIT column descriptions
 		 */

--- a/src/com/asetune/pcs/report/content/sqlserver/SqlServerTopCmExecQueryStats.java
+++ b/src/com/asetune/pcs/report/content/sqlserver/SqlServerTopCmExecQueryStats.java
@@ -264,6 +264,122 @@ extends SqlServerAbstract
 		return list;
 	}
 
+	/**
+	 * Set descriptions for the table, and the columns
+	 */
+	private void setSectionDescription(ResultSetTableModel rstm)
+	{
+		if (rstm == null)
+			return;
+		
+		// Section description
+		rstm.setDescription(
+				"Top SQL Statements (and it's Query Plan)...  (ordered by: " + _sqlOrderByCol + ") <br>" +
+				"<br>" +
+				"SqlServer Source table is 'dm_exec_query_stats'. <br>" +
+				"PCS Source table is 'CmExecQueryStats_diff'. (PCS = Persistent Counter Store) <br>" +
+				"");
+
+		// Columns description
+		rstm.setColumnDescription("dbname"                               , "Name of the database");
+		rstm.setColumnDescription("query_hash"                           , "Binary hash value calculated on the query and used to identify queries with similar logic. \nYou can use the query hash to determine the aggregate resource usage for queries that differ only by literal values");
+		rstm.setColumnDescription("SqlText"                              , "SQL Text typical for the 'query_hash'");
+		rstm.setColumnDescription("ExecPlan"                             , "The Execution Plan");
+		rstm.setColumnDescription("plan__count"                          , "");
+		rstm.setColumnDescription("efficiency_pct"                       , "How efficient is the statement. \n" +
+		                                                                   "This is a percentage calculation of how well we have used the CPU for this statement... or more precise: 'total_worker_time_ms__sum' / 'AvgDop' / 'total_elapsed_time_ms__sum' * 100.0 \n" +
+		                                                                   "The lower percentage, the more 'waitTime' we have. (it can be physical IO, blocking locks, Waiting to be sceduled or similar) \n" + 
+		                                                                   "And if it's a parallel query, where the DOP might be skewed (work is not evenly distributed over the worker threads), the percent will be 'lower'...");
+
+		rstm.setColumnDescription("execution_count__chart"               , "Chart showing 'execution count' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statement was executed.");
+		rstm.setColumnDescription("execution_count__sum"                 , "Number of times that the plan has been executed.");
+		rstm.setColumnDescription("creation_time__min"                   , "When was the plan compiled. The 'oldest' time... min(creation_time)");
+		rstm.setColumnDescription("last_execution_time__max"             , "Latest time when it was executed");
+                                                                         
+		rstm.setColumnDescription("elapsed_time__chart"                  , "Chart showing 'elapsed_time' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements elapsed time.");
+		rstm.setColumnDescription("total_elapsed_time_ms__sum"           , "Summary of all 'elapsed_time' for the recorded period ");
+		rstm.setColumnDescription("AvgElapsedTimeMs"                     , "Average 'elapsed_time' per execution.");
+		                                                                 
+		rstm.setColumnDescription("worker_time__chart"                   , "Chart showing 'worker_time' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements used CPU time.");
+		rstm.setColumnDescription("total_worker_time_ms__sum"            , "Actual CPU spent on this statement in the recording period.");
+		rstm.setColumnDescription("AvgWorkerTimeMs"                      , "Average 'worker_time' per execution.");
+		                                                                 
+		rstm.setColumnDescription("est_wait_time__chart"                 , "Chart showing 'wait_time' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) what the statements was waiting for 'stuff'.");
+		rstm.setColumnDescription("total_est_wait_time_ms__sum"          , "Summary of all 'wait_time' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgEstWaitTimeMs"                     , "Average 'wait_time' per execution.");
+		                                                                 
+		rstm.setColumnDescription("physical_reads__chart"                , "Chart showing 'physical_reads' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements was doing physical_reads.");
+		rstm.setColumnDescription("total_physical_reads__sum"            , "Summary of all 'physical_reads' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgPhysicalReads"                     , "Average 'physical_reads' per execution.");
+		                                                                 
+		rstm.setColumnDescription("logical_writes__chart"                , "Chart showing 'logical_writes' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements was doing logical_writes.");
+		rstm.setColumnDescription("total_logical_writes__sum"            , "Summary of all 'logical_writes' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgLogicalWrites"                     , "Average 'logical_writes' per execution.");
+		                                                                 
+		rstm.setColumnDescription("logical_reads__chart"                 , "Chart showing 'logical_reads' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements was doing logical_reads.");
+		rstm.setColumnDescription("total_logical_reads__sum"             , "Summary of all 'logical_reads' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgLogicalReads"                      , "Average 'logical_reads' per execution.");
+		                                                                 
+		rstm.setColumnDescription("logical_reads_mb__chart"              , "Chart showing 'logical_reads_mb' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements was doing logical_reads_mb. (this is the same as 'logical_reads' / 128.0 ");
+		rstm.setColumnDescription("total_logical_reads_mb__sum"          , "Summary of all 'logical_reads_mb' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgLogicalReadsMb"                    , "Average 'logical_reads_mb' per execution.");
+		                                                                 
+		rstm.setColumnDescription("clr_time__chart"                      , "Chart showing 'clr_time' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements was doing clr_time.");
+		rstm.setColumnDescription("total_clr_time_ms__sum"               , "Summary of all 'clr_time' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgClrTimeMs"                         , "Average 'clr_time' per execution.");
+		                                                                 
+		rstm.setColumnDescription("rows__chart"                          , "Chart showing 'rows affected' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements was returning or ins/upd/del rows.");
+		rstm.setColumnDescription("total_rows__sum"                      , "Summary of all 'rows affected' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgRows"                              , "Average 'rows affected' per execution.");
+		                                                                 
+		rstm.setColumnDescription("dop__chart"                           , "Chart showing 'dop' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements was doing work in parallel, with the number of workers.");
+		rstm.setColumnDescription("total_dop__sum"                       , "Summary of all 'dop' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgDop"                               , "Average 'dop' per execution.");
+		                                                                 
+		rstm.setColumnDescription("grant_kb__chart"                      , "Chart showing 'grant_kb' in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements was requesting memory grants, and how large they were.");
+		rstm.setColumnDescription("total_grant_kb__sum"                  , "Summary of all 'grant_kb' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgGrantKb"                           , "Average 'grant_kb' per execution.");
+		                                                                 
+		rstm.setColumnDescription("total_grant_mb__sum"                  , "Summary of all 'grant_mb' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgGrantMb"                           , "Average 'grant_mb' per execution.");
+		                                                                 
+		rstm.setColumnDescription("total_used_grant_kb__sum"             , "Summary of all 'used_grant_kb' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgUsedGrantKb"                       , "Average 'used_grant_kb' per execution.");
+		                                                                 
+		rstm.setColumnDescription("total_ideal_grant_kb__sum"            , "Summary of all 'ideal_grant_kb' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgIdealGrantKb"                      , "Average 'ideal_grant_kb' per execution.");
+		                                                                 
+		rstm.setColumnDescription("total_reserved_threads__sum"          , "Summary of all 'reserved_threads' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgReservedThreads"                   , "Average 'reserved_threads' per execution.");
+		                                                                 
+		rstm.setColumnDescription("total_used_threads__sum"              , "Summary of all 'used_threads' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgUsedThreads"                       , "Average 'used_threads' per execution.");
+		
+		rstm.setColumnDescription("total_columnstore_segment_reads__sum" , "Summary of all 'columnstore_segment_reads' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgColumnstoreSegmentReads"           , "Average 'columnstore_segment_reads' per execution.");
+		
+		rstm.setColumnDescription("total_columnstore_segment_skips__sum" , "Summary of all 'columnstore_segment_skips' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgColumnstoreSegmentSkips"           , "Average 'columnstore_segment_skips' per execution.");
+		
+		rstm.setColumnDescription("spills__chart"                        , "Chart showing 'spills' to tempdb in a time period (normally 10 minutes)\nSo you can see when in the period (probably last 24 hours) the statements was spiiling to tempdb.");
+		rstm.setColumnDescription("total_spills__sum"                    , "Summary of all 'spills' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgSpills"                            , "Average 'spills' per execution.");
+		
+		rstm.setColumnDescription("total_page_server_reads__sum"         , "Summary of all 'grant_kb' for this statement in the recording period.");
+		rstm.setColumnDescription("AvgPageServerReads"                   , "Average 'grant_kb' per execution.");
+		
+		rstm.setColumnDescription("plan_handle"                          , "The 'id' of the execution plan.");
+		rstm.setColumnDescription("samples__count"                       , "Number of records for this 'query_hash' that was found in the PCS (Persistent Counter Storage)");
+		rstm.setColumnDescription("SessionSampleTime__min"               , "First record found in the PCS (Persistent Counter Storage) for this 'query_hash'.");
+		rstm.setColumnDescription("SessionSampleTime__max"               , "Last record found in the PCS (Persistent Counter Storage) for this 'query_hash'.");
+		rstm.setColumnDescription("Duration"                             , "Number of HH:MM:SS this 'query_hash'... or: 'SessionSampleTime__min' - 'SessionSampleTime__max'");
+		rstm.setColumnDescription("newDiffRow_sum"                       , "");
+	}
+//	TODO; // do same "stuff" for Query Store 
+//	TODO; // also add section for "efficiency_pct - sort-on-low-pct"
+//	TODO; // also add section for "parallel -- efficiency_pct - sort-on-low-pct"
+//	TODO; // look at how we can do "plan_count" better...
+
 	@Override
 	public String[] getMandatoryTables()
 	{
@@ -308,11 +424,15 @@ extends SqlServerAbstract
 		// Used by "sparkline" charts to filter out "new diff/rate" rows
 		String whereFilter_skipNewDiffRateRows = !skipNewDiffRateRows ? "" : sql_and_skipNewOrDiffRateRows;
 		
-//		TODO; // add cpu_efficiency_pct = total_worker_time / total_dop / total_elapsed_time * 100.0
+//		TODO; // add cpu_efficiency_pct = total_worker_time / avg_dop / total_elapsed_time * 100.0
 //		TODO; // same thing for Query Store
 //		TODO; // Add one extra REPORT_TYPE for "INEFFICIENT_CPU" -- for "any statements"
 //		TODO; // Add one extra REPORT_TYPE for "INEFFICIENT_DOP" -- Only where POD > 1
 		
+		String col_efficiency_pct = "";
+		if (dummyRstm.hasColumnNoCase("total_worker_time") && dummyRstm.hasColumnNoCase("total_dop") && dummyRstm.hasColumnNoCase("total_elapsed_time"))
+			col_efficiency_pct = "    ,cast(sum([total_worker_time]) / (sum([total_dop]) * 1.0 / nullif(sum([execution_count]), 0)) / sum([total_elapsed_time]) * 100.0 as numeric(9,1)) as [efficiency_pct] \n";
+
 		String col_total_elapsed_time_ms__sum           = !dummyRstm.hasColumnNoCase("total_elapsed_time"             ) ? "" : "    ,sum([total_elapsed_time]/1000.0)       as [total_elapsed_time_ms__sum]           \n"; 
 		String col_total_worker_time_ms__sum            = !dummyRstm.hasColumnNoCase("total_worker_time"              ) ? "" : "    ,sum([total_worker_time]/1000.0)        as [total_worker_time_ms__sum]            \n"; 
 		String col_total_est_wait_time_ms__sum          = !dummyRstm.hasColumnNoCase("total_elapsed_time"             ) ? "" : "    ,sum([total_elapsed_time]/1000.0) - sum([total_worker_time]/1000.0) as [total_est_wait_time_ms__sum]   \n"; 
@@ -406,59 +526,6 @@ extends SqlServerAbstract
 			col_SqlText = "SqlText$dcc$";
 
 
-//		String sql = getCmDiffColumnsAsSqlComment("CmActiveStatements")
-//			    + "select top " + topRows + " \n"
-//			    + "     [dbname] \n"
-//			    + "    ,[plan_handle] \n"
-//			    + "    ,max([query_plan_hash])                 as [query_plan_hash] \n"
-//			    + "    ,max([query_hash])                      as [query_hash] \n"
-//			    + "    ,count(*)                               as [samples__count] \n"
-//			    + "    ,min([SessionSampleTime])               as [SessionSampleTime__min] \n"
-//			    + "    ,max([SessionSampleTime])               as [SessionSampleTime__max] \n"
-//			    + "    ,cast('' as varchar(30))                as [Duration] \n"
-////			    + "    ,sum([CmSampleMs])                      as [CmSampleMs__sum] \n"
-//			    + "    \n"
-//			    + "    ,cast('' as varchar(512))               as [execution_count__chart] \n"
-//			    + "    ,sum([execution_count])                 as [execution_count__sum] \n"
-//			    + "    ,min([creation_time])                   as [creation_time__min] \n"
-//			    + "    ,max([last_execution_time])             as [last_execution_time__max] \n"
-//			    + "    \n"
-//			    + col_total_worker_time__chart            
-//			    + col_total_worker_time__sum               + col_AvgWorkerTimeUs            
-//			    + col_total_physical_reads__chart
-//			    + col_total_physical_reads__sum            + col_AvgPhysicalReads           
-//			    + col_total_logical_writes__sum            + col_AvgLogicalWrites           
-//			    + col_total_logical_reads__chart
-//			    + col_total_logical_reads__sum             + col_AvgLogicalReads            
-//			    + col_total_clr_time__sum                  + col_AvgClrTimeUs               
-//			    + col_total_elapsed_time__sum              + col_AvgElapsedTimeUs           
-//			    + col_total_rows__sum                      + col_AvgRows                    
-//			    + col_max_dop__chart
-//			    + col_total_dop__sum                       + col_AvgDop                     
-//			    + col_max_grant_kb__chart
-//			    + col_total_grant_kb__sum                  + col_AvgGrantKb                 
-//			    + col_total_used_grant_kb__sum             + col_AvgUsedGrantKb             
-//			    + col_total_ideal_grant_kb__sum            + col_AvgIdealGrantKb            
-//			    + col_total_reserved_threads__sum          + col_AvgReservedThreads         
-//			    + col_total_used_threads__sum              + col_AvgUsedThreads             
-//			    + col_total_columnstore_segment_reads__sum + col_AvgColumnstoreSegmentReads 
-//			    + col_total_columnstore_segment_skips__sum + col_AvgColumnstoreSegmentSkips 
-//			    + col_total_spills__chart
-//			    + col_total_spills__sum                    + col_AvgSpills                  
-//			    + col_total_page_server_reads__sum         + col_AvgPageServerReads         
-//			    + "    \n"
-////			    + "    ,max([SqlText])                         as [SqlText] \n"
-//			    + "    ,max([" + col_SqlText +"])                    as [SqlText] \n"
-//				+ "from [CmExecQueryStats_diff] \n"
-//				+ "where [CmNewDiffRateRow] = 0 -- only records that has been diff calculations (not first time seen, when it swaps in/out due to execution every x minute) \n"
-//				+ "  and [execution_count] > 0 \n"
-////				+ "  and [AvgServ_ms] > " + _aboveServiceTime + " \n"
-////				+ "  and [TotalIOs]   > " + _aboveTotalIos    + " \n"
-//				+ getReportPeriodSqlWhere()
-//				+ "group by [plan_handle] \n"
-//				+ "order by " + orderByCol + " desc \n"
-//			    + "";
-		
 //FIXME; group by 'query_hash' or 'query_plan_hash' ... also check that we pick up the correct PLAN in below table
 //Possibly; add link directly in the table for 'plan_handle' instead of the below table!!!
 
@@ -469,11 +536,15 @@ extends SqlServerAbstract
 			    + "    ,max([" + col_SqlText +"])              as [SqlText] \n"
 			    + "    ,cast('' as varchar(30))                as [ExecPlan] \n"
 			    + "    \n"
-			    + "    ,count(*)                               as [plan__count] \n" 
+			    + "    ,count(DISTINCT [query_plan_hash])      as [plan_hash__count] \n" 
+			    + "    ,count(DISTINCT [plan_handle])          as [plan_handle__count] \n" 
+//			    + "    ,count([query_plan_hash])               as [plan__count] \n" 
+//			    + "    ,count(DISTINCT [query_plan_hash])      as [distinct_plan__count] \n" 
 			    // or should the above be be:
 			    		// number_of_plans     = COUNT_BIG(qs.query_plan_hash)          // from https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/blob/dev/sp_BlitzCache.sql
 			    		// distinct_plan_count = COUNT_BIG(DISTINCT qs.query_plan_hash) // from https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/blob/dev/sp_BlitzCache.sql
 			    + "    \n"
+			    + col_efficiency_pct
 			    + "    ,cast('' as varchar(512))               as [execution_count__chart] \n"
 			    + "    ,sum([execution_count])                 as [execution_count__sum] \n"
 			    + "    ,min([creation_time])                   as [creation_time__min] \n"
@@ -1191,24 +1262,6 @@ extends SqlServerAbstract
 //		
 //		rstm.setValueAtWithOverride(calc, r, pos_dest);
 //	}
-	
-
-	/**
-	 * Set descriptions for the table, and the columns
-	 */
-	private void setSectionDescription(ResultSetTableModel rstm)
-	{
-		if (rstm == null)
-			return;
-		
-		// Section description
-		rstm.setDescription(
-				"Top SQL Statements (and it's Query Plan)...  (ordered by: " + _sqlOrderByCol + ") <br>" +
-				"<br>" +
-				"SqlServer Source table is 'dm_exec_query_stats'. <br>" +
-				"PCS Source table is 'CmExecQueryStats_diff'. (PCS = Persistent Counter Store) <br>" +
-				"");
-	}
 }
 
 /*

--- a/src/com/asetune/tools/sqlw/JsonConfigDialog.java
+++ b/src/com/asetune/tools/sqlw/JsonConfigDialog.java
@@ -1,0 +1,280 @@
+/*******************************************************************************
+ * Copyright (C) 2010-2020 Goran Schwarz
+ * 
+ * This file is part of DbxTune
+ * DbxTune is a family of sub-products *Tune, hence the Dbx
+ * Here are some of the tools: AseTune, IqTune, RsTune, RaxTune, HanaTune, 
+ *          SqlServerTune, PostgresTune, MySqlTune, MariaDbTune, Db2Tune, ...
+ * 
+ * DbxTune is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ * 
+ * DbxTune is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with DbxTune.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @author <a href="mailto:goran_schwarz@hotmail.com">Goran Schwarz</a>
+ */
+
+package com.asetune.tools.sqlw;
+
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.util.Map;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JPanel;
+
+import com.asetune.gui.swing.GLabel;
+import com.asetune.utils.Configuration;
+import com.asetune.utils.SwingUtils;
+
+import net.miginfocom.swing.MigLayout;
+
+public class JsonConfigDialog
+	extends JDialog
+	implements ActionListener
+{
+	private static final long serialVersionUID = 1L;
+
+	private Map<String, String>     _outputMap      = null; 
+//	private Map<String, JTextField> _componentMap   = null; 
+
+	private GLabel      _description         = new GLabel("<html>"
+			+ "Various settings for how to copy to JSON (JavaScript Object Notation)<br>"
+			+ "from the output/ResultSet panel into the clipboard.<br>"
+			+ "This so you can do Ctrl-V into another editor."
+			+ "</html>");
+
+	private JCheckBox   _copyOnlyRs_chk      = new JCheckBox("Only Copy ResultSets");
+	private JCheckBox   _copyMetaData_chk    = new JCheckBox("Include MetaData");
+	private JCheckBox   _doPrettyPrint_chk   = new JCheckBox("Pretty Print");
+
+	private JCheckBox   _tsAsIso8601_chk     = new JCheckBox("Timestamps as ISO-8601");
+	
+	private JButton     _ok             = new JButton("OK");
+	private JButton     _cancel         = new JButton("Cancel");
+	private JButton     _apply          = new JButton("Apply");
+	private boolean     _showApply      = false;
+
+	private JsonConfigDialog(Window owner, String title, boolean showApply)
+	{
+		super(owner, title);
+		setModal(true);
+		_showApply = showApply;
+		initComponents();
+		pack();
+		
+		// Focus to 'OK', escape to 'CANCEL'
+		SwingUtils.installEscapeButton(this, _cancel);
+		SwingUtils.setFocus(_ok);
+	}
+
+
+	public static Map<String, String> showDialog(Window owner)
+	{
+		JsonConfigDialog params = new JsonConfigDialog(owner, "JSON Config", false);
+		params.setLocationRelativeTo(owner);
+		params.setVisible(true);
+		params.dispose();
+
+		return params._outputMap;
+	}
+
+	/*---------------------------------------------------
+	** BEGIN: component initialization
+	**---------------------------------------------------
+	*/
+	protected void initComponents() 
+	{
+		JPanel panel = new JPanel();
+		panel.setLayout(new MigLayout("insets 20 20","[][grow]",""));   // insets Top Left Bottom Right
+
+		// Some tool tip
+//		_description        .setToolTipText("");
+		_copyOnlyRs_chk     .setToolTipText("Only Copy ResultSets, skip Messages and Other Informational Texts.");
+		_copyMetaData_chk   .setToolTipText("Include MetaData etc in the JSON. (This will create a bigger JSON text, but with more information about columns etc)");
+		_doPrettyPrint_chk  .setToolTipText("One long 'chunk' of text, or in a more readable format (with newlines between fields).");
+		_tsAsIso8601_chk    .setToolTipText("Should JDBC Datatype 'TIMESTAMP' be printed as a Number (milliseconds since epoch) or as a String in ISO 8601 format (yyyy-MM-dd'T'HH:mm:ss.SSSXXX).");
+		
+		// Listen for "return" and any other "key pressing"
+		// This simply enables/disable the "apply" button if anything was changed.
+		panel.add(_description        , "span, wrap 20");
+
+		panel.add(_copyOnlyRs_chk     , "wrap");
+		panel.add(_copyMetaData_chk   , "wrap");
+		panel.add(_doPrettyPrint_chk  , "wrap 15");
+
+		panel.add(_tsAsIso8601_chk    , "wrap");
+
+		setStartValues();
+		checkForChanges();
+		
+		_copyOnlyRs_chk     .addActionListener(_actionListener);
+		_copyMetaData_chk   .addActionListener(_actionListener);
+		_doPrettyPrint_chk  .addActionListener(_actionListener);
+		_tsAsIso8601_chk    .addActionListener(_actionListener);
+
+		// ADD the OK, Cancel, Apply buttons
+		panel.add(_ok,     "tag ok,     gap top 20, skip, split, bottom, right, push");
+		panel.add(_cancel, "tag cancel,                   split, bottom");
+		if (_showApply)
+		panel.add(_apply,  "tag apply,                    split, bottom");
+
+		// Initial state for buttons
+		_apply.setEnabled(false);
+		
+		setContentPane(panel);
+
+		// ADD ACTIONS TO COMPONENTS
+		_ok           .addActionListener(this);
+		_cancel       .addActionListener(this);
+		_apply        .addActionListener(this);
+	}
+	
+	private void setStartValues()
+	{
+		boolean copyOnlyRs    = Configuration.getCombinedConfiguration().getBooleanProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_ONLY_RS       , QueryWindow.DEFAULT_COPY_RESULTS_JSON_ONLY_RS);
+		boolean copyMetaData  = Configuration.getCombinedConfiguration().getBooleanProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_METADATA      , QueryWindow.DEFAULT_COPY_RESULTS_JSON_METADATA);
+		boolean doPrettyPrint = Configuration.getCombinedConfiguration().getBooleanProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_PRETTY_PRINT  , QueryWindow.DEFAULT_COPY_RESULTS_JSON_PRETTY_PRINT);
+		boolean tsAsIso_8601  = Configuration.getCombinedConfiguration().getBooleanProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_TS_AS_ISO_8601, QueryWindow.DEFAULT_COPY_RESULTS_JSON_TS_AS_ISO_8601);
+
+		_copyOnlyRs_chk     .setSelected(copyOnlyRs);
+		_copyMetaData_chk   .setSelected(copyMetaData);
+		_doPrettyPrint_chk  .setSelected(doPrettyPrint);
+		_tsAsIso8601_chk    .setSelected(tsAsIso_8601);
+	}
+	/*---------------------------------------------------
+	** END: component initialization
+	**---------------------------------------------------
+	*/
+
+	
+	private void apply()
+	{
+		_apply.setEnabled(false);
+
+		final Configuration tmpConf = Configuration.getInstance(Configuration.USER_TEMP);
+
+		tmpConf.setProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_ONLY_RS       , _copyOnlyRs_chk    .isSelected());
+		tmpConf.setProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_METADATA      , _copyMetaData_chk  .isSelected());
+		tmpConf.setProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_PRETTY_PRINT  , _doPrettyPrint_chk .isSelected());
+		tmpConf.setProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_TS_AS_ISO_8601, _tsAsIso8601_chk   .isSelected());
+		
+		tmpConf.save();
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent e)
+	{
+		Object source = e.getSource();
+
+		// --- BUTTON: OK ---
+		if (_ok.equals(source))
+		{
+			apply();
+			setVisible(false);
+		}
+
+		// --- BUTTON: CANCEL ---
+		if (_cancel.equals(source))
+		{
+			setVisible(false);
+		}
+
+		// --- BUTTON: APPLY ---
+		if (_apply.equals(source))
+		{
+			apply();
+		}
+	}
+
+	private ActionListener     _actionListener  = new ActionListener()
+	{
+		@Override
+		public void actionPerformed(ActionEvent actionevent)
+		{
+			checkForChanges();
+		}
+	};
+	private KeyListener        _keyListener  = new KeyListener()
+	{
+		 // Changes in the fields are visible first when the key has been released.
+		@Override public void keyPressed (KeyEvent keyevent) {}
+		@Override public void keyTyped   (KeyEvent keyevent) {}
+		@Override public void keyReleased(KeyEvent keyevent) { checkForChanges(); }
+	};
+
+	private void checkForChanges()
+	{
+		boolean enabled = false;
+
+//		boolean rfc4180 = _useRfc4180_chk.isSelected();
+//		_columnSeparator_txt.setEnabled(!rfc4180);
+//		_rowSeparator_txt   .setEnabled(!rfc4180);
+
+		
+		
+//		for (Map.Entry<String,JTextField> entry : _componentMap.entrySet()) 
+//		{
+//			String key      = entry.getKey();
+//			String valueNow = entry.getValue().getText();
+//			String valueIn  = _inputMap.get(key);
+//
+//			if ( ! valueNow.equals(valueIn) )
+//			{
+//				enabled = true;
+//				break;
+//			}
+//		}
+		_apply.setEnabled(enabled);
+	}
+
+	//--------------------------------------------------
+	// TEST-CODE
+	//--------------------------------------------------
+//	public static void main(String[] args)
+//	{
+//		try
+//		{
+//			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+//		}
+//		catch (Exception e)
+//		{
+//			e.printStackTrace();
+//		}
+//
+//		LinkedHashMap<String,String> in = new LinkedHashMap<String,String>();
+//		in.put("Input Fileld One", "123");
+//		in.put("Ke theis",         "1");
+//		in.put("And thrre",        "nisse");
+//		in.put("Yupp",             "kalle");
+//		Map<String,String> results = showParameterDialog(null, "Test Parameters", in, true);
+//		
+//		if (results == null)
+//			System.out.println("Cancel");
+//		else
+//		{
+//			for (Map.Entry<String,String> entry : results.entrySet()) 
+//			{
+//				String key = entry.getKey();
+//				String val = entry.getValue();
+//
+//				System.out.println("key='"+key+"', val='"+val+"'.");
+//			}
+//		}
+//	}
+}
+

--- a/src/com/asetune/tools/sqlw/QueryWindow.java
+++ b/src/com/asetune/tools/sqlw/QueryWindow.java
@@ -10991,6 +10991,9 @@ checkPanelSize(_resPanel, comp);
 	public final static String  PROPKEY_COPY_RESULTS_CSV             = PROPKEY_APP_PREFIX + "results.copy.as.csv";
 	public final static boolean DEFAULT_COPY_RESULTS_CSV             = false;
 
+	public final static String  PROPKEY_COPY_RESULTS_JSON            = PROPKEY_APP_PREFIX + "results.copy.as.json";
+	public final static boolean DEFAULT_COPY_RESULTS_JSON            = false;
+	
 	
 	public final static String  PROPKEY_COPY_RESULTS_CSV_RFC_4180    = PROPKEY_APP_PREFIX + "results.copy.as.csv.rfc.4180";
 	public final static boolean DEFAULT_COPY_RESULTS_CSV_RFC_4180    = true;
@@ -11015,6 +11018,20 @@ checkPanelSize(_resPanel, comp);
 	public final static boolean DEFAULT_COPY_RESULTS_EXCEL           = false;
 
 
+	public final static String  PROPKEY_COPY_RESULTS_JSON_ONLY_RS        = PROPKEY_APP_PREFIX + "results.copy.as.json.only.rs";
+	public final static boolean DEFAULT_COPY_RESULTS_JSON_ONLY_RS        = true;
+
+	public final static String  PROPKEY_COPY_RESULTS_JSON_METADATA       = PROPKEY_APP_PREFIX + "results.copy.as.json.metadata";
+	public final static boolean DEFAULT_COPY_RESULTS_JSON_METADATA       = true;
+
+	public final static String  PROPKEY_COPY_RESULTS_JSON_PRETTY_PRINT   = PROPKEY_APP_PREFIX + "results.copy.as.json.prettyPrint";
+	public final static boolean DEFAULT_COPY_RESULTS_JSON_PRETTY_PRINT   = true;
+
+	public final static String  PROPKEY_COPY_RESULTS_JSON_TS_AS_ISO_8601 = PROPKEY_APP_PREFIX + "results.copy.as.json.ts.iso_8601";
+	public final static boolean DEFAULT_COPY_RESULTS_JSON_TS_AS_ISO_8601 = true;
+
+
+
 	private JPopupMenu createCopyResultsPopupMenu(final JButton button)
 	{
 		// Do PopupMenu
@@ -11031,17 +11048,21 @@ checkPanelSize(_resPanel, comp);
 				// remove all old items (if any)
 				popupMenu.removeAll();
 
-				final JMenuItem ascii_mi  = new JRadioButtonMenuItem("<html><b>ASCII</b>          - <i><font color='green'>Tables will be copied into ascii format         </font></i></html>", conf.getBooleanProperty(PROPKEY_COPY_RESULTS_ASCII, DEFAULT_COPY_RESULTS_ASCII));
-				final JMenuItem html_mi   = new JRadioButtonMenuItem("<html><b>HTML</b>           - <i><font color='green'>Copy as HTML Tags                               </font></i></html>", conf.getBooleanProperty(PROPKEY_COPY_RESULTS_HTML,  DEFAULT_COPY_RESULTS_HTML));
-				final JMenuItem excel_mi  = new JRadioButtonMenuItem("<html><b>Excel</b>          - <i><font color='green'>Write to a Excel file                           </font></i></html>", conf.getBooleanProperty(PROPKEY_COPY_RESULTS_EXCEL, DEFAULT_COPY_RESULTS_EXCEL));
-				final JMenuItem csv_mi    = new JRadioButtonMenuItem("<html><b>CSV</b>            - <i><font color='green'>Commas Separated Values Format                  </font></i></html>", conf.getBooleanProperty(PROPKEY_COPY_RESULTS_CSV,   DEFAULT_COPY_RESULTS_CSV));
-				final JMenuItem csvCfg_mi = new JMenuItem           ("<html><b>CSV, Config...</b> - <i><font color='green'>Opens a Dialog, where you can set separators etc</font></i></html>");
+				final JMenuItem ascii_mi   = new JRadioButtonMenuItem("<html><b>ASCII</b>           - <i><font color='green'>Tables will be copied into ascii format         </font></i></html>", conf.getBooleanProperty(PROPKEY_COPY_RESULTS_ASCII, DEFAULT_COPY_RESULTS_ASCII));
+				final JMenuItem html_mi    = new JRadioButtonMenuItem("<html><b>HTML</b>            - <i><font color='green'>Copy as HTML Tags                               </font></i></html>", conf.getBooleanProperty(PROPKEY_COPY_RESULTS_HTML,  DEFAULT_COPY_RESULTS_HTML));
+				final JMenuItem excel_mi   = new JRadioButtonMenuItem("<html><b>Excel</b>           - <i><font color='green'>Write to a Excel file                           </font></i></html>", conf.getBooleanProperty(PROPKEY_COPY_RESULTS_EXCEL, DEFAULT_COPY_RESULTS_EXCEL));
+				final JMenuItem csv_mi     = new JRadioButtonMenuItem("<html><b>CSV</b>             - <i><font color='green'>Commas Separated Values Format                  </font></i></html>", conf.getBooleanProperty(PROPKEY_COPY_RESULTS_CSV,   DEFAULT_COPY_RESULTS_CSV));
+				final JMenuItem csvCfg_mi  = new JMenuItem           ("<html><b>CSV, Config...</b>  - <i><font color='green'>Opens a Dialog, where you can set separators etc</font></i></html>");
+				final JMenuItem json_mi    = new JRadioButtonMenuItem("<html><b>JSON</b>            - <i><font color='green'>Tables will be copied in JSON format            </font></i></html>", conf.getBooleanProperty(PROPKEY_COPY_RESULTS_JSON,  DEFAULT_COPY_RESULTS_JSON));
+				final JMenuItem jsonCfg_mi = new JMenuItem           ("<html><b>JSON, Config...</b> - <i><font color='green'>Opens a Dialog, where you can set separators etc</font></i></html>");
 
 				ButtonGroup group = new ButtonGroup();
 				group.add(ascii_mi);
 				group.add(html_mi);
 				group.add(excel_mi);
 				group.add(csv_mi);
+				group.add(json_mi);
+				group.add(jsonCfg_mi);
 
 				// Actions
 				ActionListener groupActionListener = new ActionListener()
@@ -11053,6 +11074,7 @@ checkPanelSize(_resPanel, comp);
 						tmpConf.setProperty(PROPKEY_COPY_RESULTS_HTML,  html_mi .isSelected());
 						tmpConf.setProperty(PROPKEY_COPY_RESULTS_EXCEL, excel_mi.isSelected());
 						tmpConf.setProperty(PROPKEY_COPY_RESULTS_CSV,   csv_mi  .isSelected());
+						tmpConf.setProperty(PROPKEY_COPY_RESULTS_JSON,  json_mi .isSelected());
 						saveProps();
 						
 						button.doClick();
@@ -11062,6 +11084,7 @@ checkPanelSize(_resPanel, comp);
 				html_mi  .addActionListener(groupActionListener);
 				excel_mi .addActionListener(groupActionListener);
 				csv_mi   .addActionListener(groupActionListener);
+				json_mi  .addActionListener(groupActionListener);
 
 				// Action for CSV Config
 				csvCfg_mi.addActionListener(new ActionListener()
@@ -11070,34 +11093,16 @@ checkPanelSize(_resPanel, comp);
 					public void actionPerformed(ActionEvent e)
 					{
 						CsvConfigDialog.showDialog(_window);
-//						String key0 = "<html>Use RFC 4180<br>http://tools.ietf.org/html/rfc4180</html>";
-//						String key1 = "Column Separator";
-//						String key2 = "Row Separator";
-//						String key3 = "NULL Value Replacement";
-//						String key4 = "Copy Headers";
-//						String key5 = "Copy Messages, etc";
-//
-//						LinkedHashMap<String, String> in = new LinkedHashMap<String, String>();
-//						in.put(key0, Configuration.getCombinedConfiguration().getBooleanProperty(PROPKEY_COPY_RESULTS_CSV_RFC_4180,    DEFAULT_COPY_RESULTS_CSV_RFC_4180) + "");
-//						in.put(key1, Configuration.getCombinedConfiguration().getPropertyRawVal( PROPKEY_COPY_RESULTS_CSV_COL_SEP,     DEFAULT_COPY_RESULTS_CSV_COL_SEP));
-//						in.put(key2, Configuration.getCombinedConfiguration().getPropertyRawVal( PROPKEY_COPY_RESULTS_CSV_ROW_SEP,     DEFAULT_COPY_RESULTS_CSV_ROW_SEP));
-//						in.put(key3, Configuration.getCombinedConfiguration().getProperty(       PROPKEY_COPY_RESULTS_CSV_NULL_OUTPUT, DEFAULT_COPY_RESULTS_CSV_NULL_OUTPUT));
-//						in.put(key4, Configuration.getCombinedConfiguration().getBooleanProperty(PROPKEY_COPY_RESULTS_CSV_HEADERS,     DEFAULT_COPY_RESULTS_CSV_HEADERS)  + "");
-//						in.put(key5, Configuration.getCombinedConfiguration().getBooleanProperty(PROPKEY_COPY_RESULTS_CSV_MESSAGES,    DEFAULT_COPY_RESULTS_CSV_MESSAGES) + "");
-//
-//						Map<String,String> results = ParameterDialog.showParameterDialog(_window, "CSV Separators", in, false);
-//
-//						if (results != null)
-//						{
-//							tmpConf.setProperty(PROPKEY_COPY_RESULTS_CSV_RFC_4180,    results.get(key0));
-//							tmpConf.setProperty(PROPKEY_COPY_RESULTS_CSV_COL_SEP,     results.get(key1));
-//							tmpConf.setProperty(PROPKEY_COPY_RESULTS_CSV_ROW_SEP,     results.get(key2));
-//							tmpConf.setProperty(PROPKEY_COPY_RESULTS_CSV_NULL_OUTPUT, results.get(key3));
-//							tmpConf.setProperty(PROPKEY_COPY_RESULTS_CSV_HEADERS,     results.get(key4));
-//							tmpConf.setProperty(PROPKEY_COPY_RESULTS_CSV_MESSAGES,    results.get(key5));
-//							
-//							saveProps();
-//						}
+					}
+				});
+
+				// Action for JSON Config
+				jsonCfg_mi.addActionListener(new ActionListener()
+				{
+					@Override
+					public void actionPerformed(ActionEvent e)
+					{
+						JsonConfigDialog.showDialog(_window);
 					}
 				});
 
@@ -11107,6 +11112,8 @@ checkPanelSize(_resPanel, comp);
 				popupMenu.add(excel_mi);
 				popupMenu.add(csv_mi);
 				popupMenu.add(csvCfg_mi);
+				popupMenu.add(json_mi);
+				popupMenu.add(jsonCfg_mi);
 			}
 			@Override public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {/*empty*/}
 			@Override public void popupMenuCanceled(PopupMenuEvent e) {/*empty*/}
@@ -11146,6 +11153,7 @@ checkPanelSize(_resPanel, comp);
 				boolean asHtml  = Configuration.getCombinedConfiguration().getBooleanProperty(PROPKEY_COPY_RESULTS_HTML,  DEFAULT_COPY_RESULTS_HTML);
 				boolean asExcel = Configuration.getCombinedConfiguration().getBooleanProperty(PROPKEY_COPY_RESULTS_EXCEL, DEFAULT_COPY_RESULTS_EXCEL);
 				boolean asCsv   = Configuration.getCombinedConfiguration().getBooleanProperty(PROPKEY_COPY_RESULTS_CSV,   DEFAULT_COPY_RESULTS_CSV);
+				boolean asJson  = Configuration.getCombinedConfiguration().getBooleanProperty(PROPKEY_COPY_RESULTS_JSON,  DEFAULT_COPY_RESULTS_JSON);
 
 				// Check what type we should copy (ASCII is the default)
 				StringBuilder sb;
@@ -11153,6 +11161,7 @@ checkPanelSize(_resPanel, comp);
 				else if (asHtml)  sb = getResultPanelAsHtml (_resPanel);
 				else if (asExcel) sb = getResultPanelAsExcel(_resPanel);
 				else if (asCsv)   sb = getResultPanelAsCsv  (_resPanel);
+				else if (asJson)  sb = getResultPanelAsJson (_resPanel);
 				else              sb = getResultPanelAsAscii(_resPanel);
 
 				if (sb != null)
@@ -11474,6 +11483,139 @@ checkPanelSize(_resPanel, comp);
 						sb.append("\n");
 					//sb.append(terminatorStr);
 				}
+			}
+		}
+		return sb;
+	}
+	private StringBuilder getResultPanelAsJson(JComponent panel)
+	{
+		boolean copyOnlyRs    = Configuration.getCombinedConfiguration().getBooleanProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_ONLY_RS       , QueryWindow.DEFAULT_COPY_RESULTS_JSON_ONLY_RS);
+		boolean copyMetaData  = Configuration.getCombinedConfiguration().getBooleanProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_METADATA      , QueryWindow.DEFAULT_COPY_RESULTS_JSON_METADATA);
+		boolean doPrettyPrint = Configuration.getCombinedConfiguration().getBooleanProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_PRETTY_PRINT  , QueryWindow.DEFAULT_COPY_RESULTS_JSON_PRETTY_PRINT);
+		boolean tsAsIso_8601  = Configuration.getCombinedConfiguration().getBooleanProperty(QueryWindow.PROPKEY_COPY_RESULTS_JSON_TS_AS_ISO_8601, QueryWindow.DEFAULT_COPY_RESULTS_JSON_TS_AS_ISO_8601);
+
+		StringBuilder sb = new StringBuilder();
+//		String terminatorStr = "\n";
+//		String terminatorStr = "----------------------------------------------------------------------------\n";
+
+		for (int i=0; i<panel.getComponentCount(); i++)
+		{
+			Component comp = (Component) panel.getComponent(i);
+			if (comp instanceof JPanel)
+			{
+				if (comp instanceof GTableFilter)
+				{
+					if (copyOnlyRs)
+						continue;
+
+					GTableFilter filter = (GTableFilter)comp;
+					if (filter.hasFilterInfo())
+					{
+						String str = filter.getFilterInfo();
+						sb.append( str );
+						if ( ! str.endsWith("\n") )
+							sb.append("\n");
+					}
+				}
+				else
+				{
+					sb.append( getResultPanelAsJson( (JPanel)comp ) );
+				}
+			}
+			else if (comp instanceof JTabbedPane)
+			{
+				JTabbedPane tp = (JTabbedPane) comp;
+				for (int t=0; t<tp.getTabCount(); t++)
+				{
+					Component tabComp = tp.getComponentAt(t);
+					if (tabComp instanceof JComponent)
+						sb.append( getResultPanelAsJson((JComponent)tabComp) );
+				}
+			}
+			else if (comp instanceof JTable)
+			{
+				JTable table = (JTable)comp;
+//				String textTable = SwingUtils.tableToString(table);
+				TableModel tm = table.getModel();
+				String textTable = "";
+				if (tm instanceof ResultSetTableModel)
+				{
+					ResultSetTableModel rstm = (ResultSetTableModel) tm;
+					try 
+					{
+						textTable = rstm.toJson(copyMetaData, doPrettyPrint, tsAsIso_8601);
+					}
+					catch (IOException ex) 
+					{
+						textTable = StringUtil.exceptionToString(ex);
+					}
+				}
+				else
+				{
+					sb.append("############################################################################### \n");
+					sb.append("## The table model in NOT supported. tm='" + tm.getClass().getName() + "' \n");
+					sb.append("## Printing a ASCII Table instead. \n");
+					sb.append("############################################################################### \n");
+					textTable = SwingUtils.tableToString(table);
+				}
+				sb.append( textTable );
+				if ( ! textTable.endsWith("\n") )
+					sb.append("\n");
+				sb.append("\n");
+				//sb.append(terminatorStr);
+			}
+			else if (comp instanceof JEditorPane)
+			{
+				if (copyOnlyRs)
+					continue;
+
+				JEditorPane text = (JEditorPane)comp;
+//				sb.append( StringUtil.stripHtml(text.getText()) );
+
+				// text.getText(), will get the actual HTML content and we just want the text
+				// so lets copy the stuff into the clipboard and get it from there :)
+				// Striping the HTML is an alternative, but that lead to other problems
+				text.selectAll();
+				text.copy();
+				text.select(0, 0);
+
+				Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+				Transferable clipData = clipboard.getContents(this);
+				String strFromClipboard;
+				try { strFromClipboard = (String) clipData.getTransferData(DataFlavor.stringFlavor); } 
+				catch (Exception ee) { strFromClipboard = ee.toString(); }
+
+				sb.append( strFromClipboard );
+				if ( ! strFromClipboard.endsWith("\n") )
+					sb.append("\n");
+				//sb.append(terminatorStr);
+			}
+			else if (comp instanceof JTextArea)  // JAseMessage extends JTextArea
+			{
+				if (copyOnlyRs)
+					continue;
+
+				JTextArea text = (JTextArea)comp;
+				String str = text.getText();
+				sb.append( str );
+				if ( ! str.endsWith("\n") )
+					sb.append("\n");
+				//sb.append(terminatorStr);
+			}
+			else if (comp instanceof JTableHeader)
+			{
+				// discard the table header, we get that info in JTable
+			}
+			else
+			{
+				if (copyOnlyRs)
+					continue;
+
+				String str = comp.toString();
+				sb.append( str );
+				if ( ! str.endsWith("\n") )
+					sb.append("\n");
+				//sb.append(terminatorStr);
 			}
 		}
 		return sb;

--- a/src/com/asetune/utils/AseSqlScript.java
+++ b/src/com/asetune/utils/AseSqlScript.java
@@ -77,10 +77,14 @@ implements SybMessageHandler, AutoCloseable
 	private boolean            _printSqlInGlobalMsgHandler = true;
 	
 	private String             _currentSqlStatement        = null;
-	private boolean            _rsAsciiTable               = false;
+	private boolean            _rsAsAsciiTable             = false;
+	private boolean            _rsAsJson                   = false;
 
-	public boolean       getRsAsAsciiTable()          { return _rsAsciiTable; }
-	public AseSqlScript  setRsAsAsciiTable(boolean b) { _rsAsciiTable = b; return this; }
+	public boolean       getRsAsAsciiTable()          { return _rsAsAsciiTable; }
+	public AseSqlScript  setRsAsAsciiTable(boolean b) { _rsAsAsciiTable = b; return this; }
+
+	public boolean       getRsAsJson()                { return _rsAsJson; }
+	public AseSqlScript  setRsAsJson(boolean b)       { _rsAsJson = b; return this; }
 
 	public AseSqlScript  setDiscardDbmsErrorNumbers(List<Integer> list) { _discardDbmsErrorNumList  = list; return this; }
 	public AseSqlScript  setDiscardDbmsErrorText   (List<String> list)  { _discardDbmsErrorTextList = list; return this; }
@@ -590,10 +594,9 @@ implements SybMessageHandler, AutoCloseable
 							ResultSetTableModel tm = new ResultSetTableModel(rs, true, sql, sql);
 
 							// Write ResultSet Content as a "string table"
-							if (_rsAsciiTable)
-								sb.append(tm.toAsciiTableString());
-							else
-								sb.append(tm.toTableString());
+							if      (_rsAsAsciiTable) sb.append(tm.toAsciiTableString());
+							else if (_rsAsJson)       sb.append(tm.toJson());
+							else                      sb.append(tm.toTableString());
 
 							// Append, messages and Warnings to output, if any
 							sb.append(getSqlWarningMsgs(stmnt, true));

--- a/src/com/asetune/utils/CountingWriter.java
+++ b/src/com/asetune/utils/CountingWriter.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (C) 2010-2019 Goran Schwarz
+ * 
+ * This file is part of DbxTune
+ * DbxTune is a family of sub-products *Tune, hence the Dbx
+ * Here are some of the tools: AseTune, IqTune, RsTune, RaxTune, HanaTune, 
+ *          SqlServerTune, PostgresTune, MySqlTune, MariaDbTune, Db2Tune, ...
+ * 
+ * DbxTune is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * DbxTune is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with DbxTune.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package com.asetune.utils;
+
+import java.io.FilterWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+public class CountingWriter 
+extends FilterWriter
+{
+	private long count;
+
+	public CountingWriter(Writer out)
+	{
+		super(out);
+	}
+
+	/**
+	 * The number of chars written. For ASCII this is the number of bytes.
+	 * 
+	 * @return the char count.
+	 */
+	public long getCharsWritten()
+	{
+		return count;
+	}
+	public void resetCharsWritten()
+	{
+		count = 0;
+	}
+
+	@Override
+	public void write(int c) throws IOException
+	{
+		super.write(c);
+		++count;
+	}
+
+	@Override
+	public void write(char[] cbuf, int off, int len) throws IOException
+	{
+		super.write(cbuf, off, len);
+		count += len;
+	}
+
+	@Override
+	public void write(String str, int off, int len) throws IOException
+	{
+		super.write(str, off, len);
+		count += len;
+	}
+}

--- a/src/com/asetune/utils/JsonUtils.java
+++ b/src/com/asetune/utils/JsonUtils.java
@@ -20,6 +20,14 @@
  ******************************************************************************/
 package com.asetune.utils;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -147,4 +155,547 @@ public class JsonUtils
 		else
 			return prettyJson;
 	}
+
+
+
+
+
+
+	public static class MissingFieldException
+	extends Exception
+	{
+		private static final long serialVersionUID = 1L;
+
+		public MissingFieldException(String msg)
+		{
+			super(msg);
+		}
+
+		public MissingFieldException(String msg, Exception ex)
+		{
+			super(msg, ex);
+		}
+	}
+	
+	/**
+	 * Get Node from a node 
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @return                   A String
+	 * @throws MissingFieldException  When the field name is not found
+	 */
+	public static JsonNode getNode(JsonNode node, String fieldName)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			throw new MissingFieldException("Expecting field '"+fieldName+"' which was not found.");
+		return n;
+	}
+
+	/**
+	 * Check if the field Exists.
+	 * @param node
+	 * @param fieldName  name of the field(s) you checking for... It may be more than one
+	 * @return 
+	 */
+	public static boolean doFieldExist(JsonNode node, String... fieldNames)
+	{
+		for (String fieldName : fieldNames)
+		{
+			if (node.get(fieldName) == null)
+				return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Get String from a node 
+	 * @param node           The node
+	 * @param fieldName      The fields name
+	 * @param defaultValue   Default value if field is not found
+	 * @return               A String
+	 */
+	public static String getString(JsonNode node, String fieldName, String defaultValue)
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			return defaultValue;
+//		if (n.isNull())
+//			return null;
+		if (n.isNull())
+			return defaultValue;
+		return n.asText();
+	}
+
+	/**
+	 * Get String from a node 
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @return                   A String
+	 * @throws MissingFieldException  When the field name is not found
+	 */
+	public static String getString(JsonNode node, String fieldName)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			throw new MissingFieldException("Expecting field '"+fieldName+"' which was not found.");
+		if (n.isNull())
+			return null;
+		return n.asText();
+	}
+
+	/**
+	 * Get String from a node 
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @return                   A String
+	 * @throws MissingFieldException  When the field name is not found
+	 */
+	public static String getStringAny(JsonNode node, String... fieldNames)
+	throws MissingFieldException
+	{
+		for (String entry : fieldNames)
+		{
+			if ( ! node.has(entry) )
+				continue;
+
+			JsonNode n = node.get(entry);
+			if (n.isNull())
+				return null;
+			return n.asText();
+		}
+		throw new MissingFieldException("Expecting any fields '" + StringUtil.toCommaStr(fieldNames) + "' but none of them was found.");
+	}
+
+	/**
+	 * Get String from a node 
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @return                   A String
+	 * @throws MissingFieldException  When the field name is not found
+	 */
+	public static String getStringAny(String defaultVal, JsonNode node, String... fieldNames)
+//	throws MissingFieldException
+	{
+		for (String entry : fieldNames)
+		{
+			if ( ! node.has(entry) )
+				continue;
+
+			JsonNode n = node.get(entry);
+			if (n.isNull())
+				return null;
+			return n.asText();
+		}
+		return defaultVal;
+	}
+
+	/**
+	 * Get String LIST from a node 
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @return                   A List of Strings
+	 * @throws MissingFieldException  When the field name is not found
+	 */
+	public static List<String> getStringList(JsonNode node, String fieldName)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			return null;
+//			throw new MissingFieldException("Expecting field '"+fieldName+"' which was not found.");
+		if (n.isNull())
+			return null;
+		
+		if ( ! n.isArray() )
+			return StringUtil.parseCommaStrToList(n.asText());
+
+		List<String> list = new ArrayList<>();
+		for(JsonNode jsonNode : n) 
+		{
+			list.add(jsonNode.asText());
+		}
+		return list;
+	}
+
+	/**
+	 * Get int value from a node
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @param defaultValue       Default value if field is not found
+	 * @return                   an int
+	 */
+	public static int getInt(JsonNode node, String fieldName, int defaultValue)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			return defaultValue;
+		return n.asInt();
+	}
+
+	/**
+	 * Get int value from a node
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @return                   an int
+	 * @throws MissingFieldException  When the field name is not found
+	 */
+	public static int getInt(JsonNode node, String fieldName)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			throw new MissingFieldException("Expecting field '"+fieldName+"' which was not found.");
+		return n.asInt();
+	}
+
+	/**
+	 * Get boolean value from a node
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @param defaultValue       Default value if field is not found
+	 * @return                   an boolean value
+	 */
+	public static boolean getBoolean(JsonNode node, String fieldName, boolean defaultValue)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			return defaultValue;
+		return n.asBoolean();
+	}
+
+	/**
+	 * Get boolean value from a node
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @throws MissingFieldException  When the field name is not found
+	 * @return                   an boolean value
+	 */
+	public static boolean getBoolean(JsonNode node, String fieldName)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			throw new MissingFieldException("Expecting field '"+fieldName+"' which was not found.");
+		return n.asBoolean();
+	}
+
+	/**
+	 * Get double value from a node
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @param defaultValue       Default value if field is not found
+	 * @return                   an double value
+	 */
+	public static double getDouble(JsonNode node, String fieldName, double defaultValue)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			return defaultValue;
+		return n.asDouble();
+	}
+
+	/**
+	 * Get double value from a node
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @throws MissingFieldException  When the field name is not found
+	 * @return                   an double value
+	 */
+	public static double getDouble(JsonNode node, String fieldName)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			throw new MissingFieldException("Expecting field '"+fieldName+"' which was not found.");
+		return n.asDouble();
+	}
+
+	/**
+	 * Get Timestamp value from a node
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @param defaultValue       Default value if field is not found
+	 * @return                   an Timestamp value
+	 */
+	public static Timestamp getTimestampAny(Timestamp defaultValue, JsonNode node, String... fieldNames)
+//	throws MissingFieldException
+	{
+		for (String entry : fieldNames)
+		{
+			if ( ! node.has(entry) )
+				continue;
+
+			JsonNode n = node.get(entry);
+			if (n.isNull())
+				return defaultValue;
+
+			try
+			{
+				return getTimestamp(node, entry);
+			}
+			catch (Exception e) 
+			{
+				return defaultValue;
+			}
+		}
+		return defaultValue;
+	}
+
+	/**
+	 * Get Timestamp value from a node
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @param defaultValue       Default value if field is not found
+	 * @return                   an Timestamp value
+	 */
+	public static Timestamp getTimestamp(JsonNode node, String fieldName, Timestamp defaultValue)
+	throws MissingFieldException
+	{
+		try
+		{
+			return getTimestamp(node, fieldName);
+		}
+		catch (Exception e) 
+		{
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * Get Timestamp value from a node
+	 * @param node               The node
+	 * @param fieldName          The fields name
+	 * @throws MissingFieldException  When the field name is not found
+	 * @return                   an Timestamp value
+	 */
+	public static Timestamp getTimestamp(JsonNode node, String fieldName)
+	throws MissingFieldException
+	{
+		JsonNode n = node.get(fieldName);
+		if (n == null)
+			throw new MissingFieldException("Expecting field '"+fieldName+"' which was not found.");
+		
+		if (n.isNull())
+			return null;
+		
+		String str = n.asText();
+		Timestamp ts = null;
+		Exception ex = null;
+
+		// if String(iso-8601), then convert it into a Timestamp 
+		try 
+		{ 
+			ts = TimeUtils.parseToTimestampIso8601(str); 
+			return ts;
+		}
+		catch (ParseException pe) 
+		{ 
+			ex = pe;
+		}
+
+		// if String(yyyy-MM-dd hh:mm:ss.SSS), then convert it into a Timestamp 
+		try 
+		{ 
+			ts = TimeUtils.parseToTimestamp(str); 
+			return ts;
+		}
+		catch (ParseException pe) 
+		{ 
+			ex = pe;
+		}
+
+		// if Long value, then convert it into a Timestamp
+		try 
+		{ 
+			long time = Long.parseLong(str);
+			return new Timestamp(time);
+		}
+		catch (NumberFormatException nfe) 
+		{ 
+			ex = nfe;
+		}
+		
+
+		throw new MissingFieldException("Problems parsing the Timestamp for field '"+fieldName+"' using value '"+str+"'. Caught: "+ex, ex); 
+	}
+
+	/**
+	 * create a Object based on what type the desired field is of
+	 * @param node               The node
+	 */
+	public static Object createObjectFromNodeType(JsonNode node)
+	{
+		if (node == null)
+			return null;
+
+		if (node.isTextual()) return node.asText();
+		if (node.isInt())     return node.asInt();
+		if (node.isBoolean()) return node.asBoolean();
+
+		if (node.isLong())       return node.asLong();
+		if (node.isDouble())     return node.asDouble();
+		if (node.isShort())      return new Short(node.asText());
+		if (node.isFloat())      return new Float(node.asText());
+		if (node.isBigDecimal()) return new BigDecimal(node.asText());
+		if (node.isBigInteger()) return new BigInteger(node.asText());
+//		if (node.isBinary())     return node.as);
+
+		return null;
+	}
+	
+	/**
+	 * Parse out multiple JSON Strings from the input value, and return them as separate strings in a list.
+	 * <p>
+	 * This extract every string "chunk" between curly braces: {...}<br>
+	 * It may be JSON or "anything else
+	 * <p>
+	 * <ul>
+	 *    <li>End Curly braces inside double quotes is ignored</li>
+	 *    <li>Escaped Curly braces is ignored</li>
+	 *    <li>Escaped Double Quotes is ignored</li>
+	 * </ul>
+	 * 
+	 *
+	 * @param input    The text to extract JSON information from. 
+	 * @return         A List of JSON text "chunks" that was extracted!
+	 */
+	// This was copied from: https://stackoverflow.com/questions/40991519/extract-json-string-from-mixed-string-with-java
+	// FIXED: It doesn't look that efficient, but lets fix that later... (I switched temp from 'String' to 'StringBuilder', which made it **much** faster)
+	// FIXED: It probably do NOT handle escaped '{' like >>>{"name":"some \} embedded string"}<<<
+	// FIXED: It probably do NOT handle '{' within Strings like >>>{"name":"some } embedded string"}<<<
+	public static List<String> getJsonObjectsFromString(String input)
+	{
+		List<Character> stack = new ArrayList<Character>();
+		List<String>    jsons = new ArrayList<String>();
+		StringBuilder   temp  = new StringBuilder();
+
+		boolean inQuote = false; // toggled every time we see " (double quote char)
+		char prevChar = ' ';
+		
+		for (char thisChar : input.toCharArray())
+		{
+			if ( stack.isEmpty() && thisChar == '{' )
+			{
+				stack.add(thisChar);
+				temp.append(thisChar);
+			}
+			else if ( ! stack.isEmpty() )
+			{
+				// add char to buffer
+				temp.append(thisChar);
+
+				// Flip "inQuote" 
+				if (thisChar == '"')
+				{
+					if ( prevChar != '\\') // If not escaped
+					{
+						inQuote = ! inQuote;
+					}
+				}
+				
+				if ( stack.get(stack.size() - 1).equals('{') && thisChar == '}')
+				{
+					if (prevChar == '\\' || inQuote)
+					{
+						// Do nothing
+					}
+					else
+					{
+						stack.remove(stack.size() - 1);
+						if ( stack.isEmpty() )
+						{
+							jsons.add(temp.toString());
+							temp = new StringBuilder();
+						}
+					}
+				}
+				else if ( thisChar == '{' || thisChar == '}' )
+				{
+					stack.add(thisChar);
+				}
+			}
+			else if ( temp.length() > 0 && stack.isEmpty() )
+			{
+				jsons.add(temp.toString());
+				temp = new StringBuilder();
+			}
+			prevChar = thisChar;
+		}
+//		for (String json : jsons)
+//		{
+//			System.out.println("#########################################");
+//			System.out.println(json);
+//		}
+
+		return jsons;
+	}
+
+//	private static void test(boolean replaceHashWithQuotes, String input, String[] expected)
+//	{
+//		if (replaceHashWithQuotes)
+//		{
+//			input = input.replace('#', '"');
+//
+//			for (int i=0; i<expected.length; i++)
+//				expected[i] = expected[i].replace('#', '"');
+//		}
+//		
+//		List<String> outputList = getJsonFromString(input);
+//		if (outputList.size() != expected.length)
+//		{
+//			System.out.println("WRONG SIZE: expectedSize=" + expected.length + ", actual=" + outputList.size() );
+//			return;
+//		}
+//		
+//		for (int i=0; i<expected.length; i++)
+//		{
+//			if ( ! expected[i].equals(outputList.get(i)) )
+//			{
+//				System.out.println("WRONG VALUE: expectedVal=|" + expected[i] + "|, actual=|" + outputList.get(i) + "|");
+//				return;
+//			}
+//		}
+//		
+//		System.out.println("SUCCESS: size()=" + outputList.size());
+//		System.out.println("         input     =|" + input + "|.");
+//		System.out.println("         outputList=" + StringUtil.toCommaStrQuoted('|', outputList));
+//		
+//	}
+//	
+//	public static void main(String[] args)
+//	{
+//		System.out.println("--------------------------");
+//		test(true, "{#name#:#value#}"                                                   , new String[] {"{#name#:#value#}"});
+//		test(true, "{#name#:#val\\#ue#}"                                                , new String[] {"{#name#:#val\\#ue#}"});
+//		test(true, "-123-{#name#:#value#}-456-{aaa=bbb}-321-"                           , new String[] {"{#name#:#value#}"                           , "{aaa=bbb}"});
+//		test(true, "-123-{#name#:#some } embedded in a string#}-456-{aaa=bbb}-321-"     , new String[] {"{#name#:#some } embedded in a string#}"     , "{aaa=bbb}"});
+//		test(true, "-123-{#name#:#some escaped \\} embedded string#}-456-{aaa=bbb}-321-", new String[] {"{#name#:#some escaped \\} embedded string#}", "{aaa=bbb}"});
+//		test(true, "-123-{#name#:some escaped \\} right curlyBrace}-456-{aaa=bbb}-321-" , new String[] {"{#name#:some escaped \\} right curlyBrace}" , "{aaa=bbb}"});
+//
+//		try
+//		{
+//			String content = FileUtils.readFile("C:\\tmp\\xxx.json", StandardCharsets.UTF_8.toString());
+////			System.out.println("Content=|"+content+"|.");
+//
+//			long startTime = System.currentTimeMillis();
+//			List<String> list = getJsonFromString(content);
+//			System.out.println("ExecTimeMs=" + TimeUtils.msDiffNow(startTime) + ", for list.size()=" + list.size());
+//
+//			for (String str : list)
+//			{
+//				System.out.println("Length=" + str.length());
+//			}
+//		}
+//		catch (IOException e)
+//		{
+//			// TODO Auto-generated catch block
+//			e.printStackTrace();
+//		}
+//	}
 }


### PR DESCRIPTION
DailySummaryReport
 * In the 'Exec/Creation time for each Report Section' also print aprox how many bytes we have written to each section

SqlServerTune
 * New Alarm: AlarmEventDeadlock -- if we had any deadlocks... (within a MovingAverage over 10 minutes)
 * PCS - On Database Rollover, If we have seen any Deadlocks... extract them using 'sp_BlitzLock' and store them in the recording.
 * CmPerfCounter -- new graph 'DeadlockDetails'
 * CmSummary -- new graph 'DeadlockCountSum'
 * CmSummary -- new column 'deadlockCount'
 * CmSummary -- raises New Alarm: AlarmEventDeadlock -- if we had any deadlocks... (within a MovingAverage over 10 minutes)
 * DSR: new Section 'Deadlocks', which prints how many deadlocks we had in last 24 hours, and print information we got from sp_BlitzLock
 * DSR: new column 'efficiency_pct' for 'QueryStore' and 'TopCmExecQueryStats' this may help decide if we have (parallel) queries that are NOT effective

PostgresTune
 * DBMS Config -- Warn about 'fsync=off'

SQL Window
 * The "Copy Result" button can now also copy ResultSets into a JSON format (long or short)