### PR TITLE
Some minor changes...

### DIFF
--- a/src/com/asetune/Version.java
+++ b/src/com/asetune/Version.java
@@ -31,10 +31,10 @@ public class Version
 {
 	public static       String PRODUCT_STRING     = "AseTune";      // Do not have spaces etc in this one
 //	public static final String VERSION_STRING     = "4.5.0";        // Use this for public releases
-	public static final String VERSION_STRING     = "4.5.0.68.dev"; // Use this for early releases
-	public static final String BUILD_STRING       = "2024-05-29/build 518";
+	public static final String VERSION_STRING     = "4.5.0.74.dev"; // Use this for early releases
+	public static final String BUILD_STRING       = "2024-07-02/build 524";
 
-	public static final String GIT_DATE_STRING    = "2024-05-29";  // try to update this
+	public static final String GIT_DATE_STRING    = "2024-07-02";  // try to update this
 	public static final String GIT_REVISION_STR   = "600";         // used by CheckForUpdates --- update this on every check-in (emulates Subversion "Revision:" tag)
 
 	public static final boolean IS_DEVELOPMENT_VERSION  = true; // if true: date expiration will be checked on startup

--- a/src/com/asetune/cache/DbmsObjectIdCache.java
+++ b/src/com/asetune/cache/DbmsObjectIdCache.java
@@ -37,7 +37,6 @@ import org.apache.log4j.Logger;
 import org.h2.tools.SimpleResultSet;
 
 import com.asetune.Version;
-import com.asetune.cache.DbmsObjectIdCache.ObjectType;
 import com.asetune.gui.ResultSetTableModel;
 import com.asetune.sql.conn.DbxConnection;
 import com.asetune.utils.Configuration;
@@ -401,6 +400,21 @@ public abstract class DbmsObjectIdCache
 		_dbid_objectId_dbmsLookupNotFoundCounter = new HashMap<>();
 		
 		_statResetCalls++;
+	}
+
+	/**
+	 * Remove cached objects for a specific database id
+	 * 
+	 * @param dbid
+	 */
+	public void clearCacheForDbid(long dbid)
+	{
+		if (_dbNamesMap       != null) _dbNamesMap       .remove(dbid);
+		if (_dbid_objectId    != null) _dbid_objectId    .remove(dbid);
+		if (_dbid_partitionId != null) _dbid_partitionId .remove(dbid);
+		if (_dbid_hobtId      != null) _dbid_hobtId      .remove(dbid);
+
+		if (_dbid_objectId_dbmsLookupNotFoundCounter != null) _dbid_objectId_dbmsLookupNotFoundCounter.remove(dbid);
 	}
 
 	/**

--- a/src/com/asetune/cache/DbmsObjectIdCacheSqlServer.java
+++ b/src/com/asetune/cache/DbmsObjectIdCacheSqlServer.java
@@ -244,6 +244,12 @@ extends DbmsObjectIdCache
 				_logger.warn("DbmsObjectIdCacheSqlServer.get(conn, lookupType=" + lookupType + ", dbid=" + dbid + " [dbname=" + dbname + "], lookupId=" + lookupId + "): Problems getting schema/table/index name. The query has timed out (after " + execTime + " ms). But the lock information will still be returned (but without the schema/table/index name.");
 				throw new TimeoutException();
 			}
+			// Msg 208, Text='Invalid object name '${dbname}.sys.objects'.'
+			else if ( ex.getErrorCode() == 208 )
+			{
+				_logger.warn("DbmsObjectIdCacheSqlServer.get(conn, lookupType=" + lookupType + ", dbid=" + dbid + " [dbname=" + dbname + "], lookupId=" + lookupId + "): Problems when executing sql: " + sql + ". SQLException Error=" + ex.getErrorCode() + ", Msg='" + StringUtil.stripNewLine(ex.getMessage()) + "', execTime=" + execTime + " ms. Clear the ObjectIdCache for dbid=" + dbid, ex);
+				clearCacheForDbid(dbid);
+			}
 			else
 			{
 				_logger.warn("DbmsObjectIdCacheSqlServer.get(conn, lookupType=" + lookupType + ", dbid=" + dbid + " [dbname=" + dbname + "], lookupId=" + lookupId + ")): Problems when executing sql: " + sql + ". SQLException Error=" + ex.getErrorCode() + ", Msg='" + StringUtil.stripNewLine(ex.getMessage()) + "', execTime=" + execTime + " ms.", ex);

--- a/src/com/asetune/central/controllers/ud/chart/UserDefinedTimelineChart.java
+++ b/src/com/asetune/central/controllers/ud/chart/UserDefinedTimelineChart.java
@@ -76,7 +76,7 @@ extends UserDefinedChartAbstract
 	@Override
 	public String[] getKnownParameters()
 	{
-		return new String[] {"startTime", "endTime", "showKeys", "keyTransform", "minDurationInSeconds", "keepNames", "skipNames", "fillEnd", "generateDummyRows", "useDefaultTooltip"};
+		return new String[] {"startTime", "endTime", "showKeys", "keyTransform", "minDurationInSeconds", "keepNames", "skipNames", "fillEnd", "generateDummyRows", "useDefaultTooltip", "onlyLevelZero"};
 	}
 
 	@Override
@@ -149,7 +149,11 @@ extends UserDefinedChartAbstract
 		map.put("useDefaultTooltip",    "Fallback to use the components default tooltip instead of the 'enhanced' one.<br>"
 		                                    + "<br>"
 		                                    + "<b>Default</b>: <code>false</code>");
-		
+
+		map.put("onlyLevelZero",        "Only show Level Zero, this to get a high level overview of the executed work.<br>"
+		                                    + "<br>"
+		                                    + "<b>Default</b>: <code>false</code>");
+
 		return map;
 	}
 
@@ -161,6 +165,7 @@ extends UserDefinedChartAbstract
 				+ "&srvName=" + getDbmsServerName()
 				+ ( getRefresh() <= 0 ? "" : "&refresh=" + getRefresh() )
 				+ "&showKeys=false"
+				+ "&onlyLevelZero=false"
 				+ "&startTime="+_defaultStartTime;
 	}
 
@@ -363,6 +368,12 @@ extends UserDefinedChartAbstract
 
 		// get 'parameters'
 		Map<String, String> urlParams = getUrlParameters();
+
+		// >>> onlyLevelZero
+		boolean onlyLevelZero = false;
+		tmpParamStr  = urlParams.get("onlyLevelZero");
+		if (tmpParamStr != null && tmpParamStr.equalsIgnoreCase("true"))
+			onlyLevelZero = true;
 
 		// >>> showKeys
 		boolean showKeys = true;
@@ -572,6 +583,13 @@ extends UserDefinedChartAbstract
 					// Remember the previous row start/end Timestamps (if we need them at next row loop)
 					prevRowStartTs = startTs;
 					prevRowEndTs   = endTs;
+
+					// If the "onlyLevelZero", the "barText" must start with "[0] "
+					if (onlyLevelZero)
+					{
+						if ( ! barText.startsWith("[0] ") )
+							continue;
+					}
 
 					// If the "duration" is not long enough, skip this record!
 					if (minDurationInSeconds != -1 && startTs != null && endTs != null)

--- a/src/com/asetune/cm/postgres/CmPgActivity.java
+++ b/src/com/asetune/cm/postgres/CmPgActivity.java
@@ -469,11 +469,11 @@ extends CountersModel
 				+ "    ,a.query \n"
 
 				+ "    ,CASE WHEN a.state != 'active' OR a.state IS NULL THEN -1 \n"
-				+ "          ELSE cast(((EXTRACT('epoch' from CLOCK_TIMESTAMP()) - EXTRACT('epoch' from a.query_start)) * 1000) as int) \n"
+				+ "          ELSE cast(((EXTRACT('epoch' from CLOCK_TIMESTAMP()) - EXTRACT('epoch' from a.query_start)) * 1000) as bigint) \n"
 				+ "     END as \"execTimeInMs\" \n"
 
 				+ "    ,CASE WHEN a.xact_start IS NULL THEN -1 \n"
-				+ "          ELSE cast(((EXTRACT('epoch' from CLOCK_TIMESTAMP()) - EXTRACT('epoch' from a.xact_start)) * 1000) as int) \n"
+				+ "          ELSE cast(((EXTRACT('epoch' from CLOCK_TIMESTAMP()) - EXTRACT('epoch' from a.xact_start)) * 1000) as bigint) \n"
 				+ "     END as \"xactTimeInMs\" \n"
 
 				+ "from pg_stat_activity a \n"
@@ -717,13 +717,13 @@ extends CountersModel
 				String state = cm.getDiffValue(r, "state") + "";
 				if ("active".equals(state))
 				{
-					int execTimeInMs = -1;
+					long execTimeInMs = -1;
 
 					// get 'execTimeInMs'
 					Object o_execTimeInMs = cm.getDiffValue(r, "execTimeInMs");
 					if (o_execTimeInMs != null && o_execTimeInMs instanceof Number)
 					{
-						execTimeInMs = ((Number)o_execTimeInMs).intValue();
+						execTimeInMs = ((Number)o_execTimeInMs).longValue();
 					}
 //					else
 //					{
@@ -736,9 +736,9 @@ extends CountersModel
 //						}
 //					}
 					
-					int StatementExecInSec = (int)execTimeInMs / 1000;
+					long StatementExecInSec = (int)execTimeInMs / 1000;
 					
-					int threshold = Configuration.getCombinedConfiguration().getIntProperty(PROPKEY_alarm_StatementExecInSec, DEFAULT_alarm_StatementExecInSec);
+					long threshold = Configuration.getCombinedConfiguration().getLongProperty(PROPKEY_alarm_StatementExecInSec, DEFAULT_alarm_StatementExecInSec);
 
 					if (debugPrint || _logger.isDebugEnabled())
 						System.out.println("##### sendAlarmRequest("+cm.getName()+"): threshold="+threshold+", StatementExecInSec='"+StatementExecInSec+"'.");

--- a/src/com/asetune/cm/sqlserver/CmSummary.java
+++ b/src/com/asetune/cm/sqlserver/CmSummary.java
@@ -1874,9 +1874,18 @@ extends CountersModel
 			if (requestsWaitingForWorkers > threshold)
 			{
 				String extendedDescText = "";
-				String extendedDescHtml = getGraphDataHistoryAsHtmlImage(GRAPH_NAME_WORKER_THREAD_USAGE);
+				String extendedDescHtml =        getGraphDataHistoryAsHtmlImage(GRAPH_NAME_WORKER_THREAD_USAGE);
 				extendedDescHtml += "<br><br>" + getGraphDataHistoryAsHtmlImage(GRAPH_NAME_TASKS_WAITING_FOR_WORKERS);
+				extendedDescHtml += "<br><br>" + getGraphDataHistoryAsHtmlImage(GRAPH_NAME_AA_CPU);
 				
+				CountersModel cmWaitStats = getCounterController().getCmByName(CmWaitStats.CM_NAME);
+				if (cmWaitStats != null)
+				{
+					extendedDescHtml += "<br><br>" + getGraphDataHistoryAsHtmlImage(CmWaitStats.GRAPH_NAME_TOXIC_TIME);
+					extendedDescHtml += "<br><br>" + getGraphDataHistoryAsHtmlImage(CmWaitStats.GRAPH_NAME_TOXIC_COUNT);
+					extendedDescHtml += "<br><br>" + getGraphDataHistoryAsHtmlImage(CmWaitStats.GRAPH_NAME_TOXIC_TPW);
+				}
+
 				AlarmEvent ae = new AlarmEventOutOfWorkerThreads(cm, threshold, requestsWaitingForWorkers);
 				ae.setExtendedDescription(extendedDescText, extendedDescHtml);
 				

--- a/src/com/asetune/history.html
+++ b/src/com/asetune/history.html
@@ -60,8 +60,10 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI>Changed the default storage for Graph/Charts from LABEL_IN_SEPARATE_COLUMN to COLUMN_NAME_IS_LABEL (now using the column name as the "label name" instead of a separate column holding the name)</LI>
 		<LI>PCS: If CountersModel number of columns changes "on the fly", we will now alter the CM PCS tables on the fly (more columns will be added, but not deleted)</LI>
 
-		<LI>CmOsVmstat:  for Linux:   Raise Alarm 'AlarmEventOsSwapThrashing' when we have paging/swapping both 'in' AND 'out' at the same time. Both 'in' AND 'out' needs to be above the threshold for 5 minutes.</LI>
-		<LI>CmOsMeminfo: for Windows: Raise Alarm 'AlarmEventOsSwapThrashing' when we have paging/swapping both 'in' AND 'out' at the same time. Both 'in' AND 'out' needs to be above the threshold for 5 minutes.</LI>
+		<LI>CmOsVmstat:    for Linux:   Raise Alarm 'AlarmEventOsSwapThrashing' when we have paging/swapping both 'in' AND 'out' at the same time. Both 'in' AND 'out' needs to be above the threshold for 5 minutes.</LI>
+		<LI>CmOsMeminfo:   for Windows: Raise Alarm 'AlarmEventOsSwapThrashing' when we have paging/swapping both 'in' AND 'out' at the same time. Both 'in' AND 'out' needs to be above the threshold for 5 minutes.</LI>
+		<LI>CmOsDiskSpace: On Windows add the 'disk label' to the 'drive name' for easier determination of what the disk may be used for</LI>
+		<LI>CmOsIostat:    On Windows add the 'disk label' to the 'drive name' for easier determination of what the disk may be used for</LI>
 		<LI>NO-GUI now starts a Management Web Server (localhost:89##), so we can do some management of configuration etc from DbxCentral web ui<br>
             Note: This is still in development...</LI>
 		<LI>Added extra "Graph Properties", so individual graphs can set "sampleType" to other than "AUTO" (for example Disk Space Available can have MIN_OVER_SAMPLES)</LI>
@@ -307,6 +309,8 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI>All CounterModels with column "program_name" and it contains a JobId and StepId the real names will be used from SqlAgentJobInfoCache (disable with: SqlServerTune.CmAny.resolve.sqlAgent.programName.enable=false)</LI>
 		<LI>PCS Transfer new QueryStore tables for SQL Server 2022</LI>
 		<LI>a bunch of cm's -- Get 'context_info' from 'dm_exec_requests' instead of 'dm_exec_connections'</LI>
+		<LI>DbmsObjectIdCache -- on "Msg 208, Text='Invalid object name 'xxxx'.'" simply clear the cache for that dbid</LI>
+		<LI>UserDefinedTimelineChart -- new option: onlyLevelZero={true|false} to only show "top" levels for 'SQL Agent Jobs'</LI>
 
 		<LI>Added Alarm: <b>AlarmEventMemoryGrantWait   </b> -- Used by CM 'CmMemoryGrantsSum' to alarm if we have anyone waiting to grab a memory grant.</LI>
 		<LI>Added Alarm: <b>AlarmEventLowOnWorkerThreads</b> -- which will be raised when we have 20 or less "worker threads" available (called from CmSummary)</LI>
@@ -337,6 +341,8 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI><b>CmActiveStatements   </b> - Mark "dop" where dop > 1 with a green color, just for easier spotting if it uses Paralell workers (this is also changed in DbxCentral)</LI>
 		<LI><b>CmActiveStatements   </b> - New columns to track "SPID Wait Info": 'SpidWaitCountSum', 'SpidWaitTimeMsSum', 'HasSpidWaitInfo', 'SpidWaitInfo'. The information is fetched from CmSpidWait (if not enabled, no info will be available)</LI>
 		<LI><b>CmActiveStatements   </b> - Added column 'sql_handle' to better track "multiSampled" SPID/row</LI>
+		<LI><b>CmActiveStatements   </b> - Added column 'tran_begin_time' -- If we have a long running statement we may also want to see the 'tran_begin_time'</LI>
+		<LI><b>CmActiveStatements   </b> - Changed logic for 'getLockSummaryForSpid', to handle timeouts in another way</LI>
 		
 		<LI><b>CmAlwaysOn           </b> - Performance enhancement</LI>
 
@@ -345,6 +351,8 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI><b>CmDatabases          </b> - added new columns 'collation_name'</LI>
 		<LI><b>CmDatabases          </b> - Added column 'is_read_only'</LI>
 		<LI><b>CmDatabases          </b> - if database is in status "SINGLE_USER", (it wont be investigated), then set Alarm "Time To Live" to 10 minutes, so we don't CANCEL/RASE the alarm to often!</LI>
+		<LI><b>CmDatabases          </b> - On Windows add the 'disk label' to the 'drive name' for easier determination of what the disk may be used for</LI>
+		<LI><b>CmDatabases          </b> - Changed logic for 'getLockSummaryForSpid', to handle timeouts in another way</LI>
 
 		<LI><b>CmDeviceIo           </b> - LogicalName - is now based om dbname and file_id (instead of master_files.name, which may not be unique enough)</LI>
 		<LI><b>CmDeviceIo           </b> - added new columns 'lname' (master_files.name), which is the 'old' LogicaName.</LI>
@@ -362,6 +370,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI><b>CmMemoryGrantsSum    </b> - For alarm AlarmEventMemoryGrantWait, attach details from CmMemoryGrants</LI>
 
 		<LI><b>CmOpenTransactions   </b> - added new column 'context_info_str' which is a String interpretation of the binary field 'context_info'</LI>
+		<LI><b>CmOpenTransactions   </b> - Changed logic for 'getLockSummaryForSpid', to handle timeouts in another way</LI>
 
 		<LI><b>CmPerfCounters       </b> - Added Chart 'Stolen Server Memory, from Buffer Pool'</LI>
 		<LI><b>CmPerfCounters       </b> - Added Chart 'DeadlockDetails'</LI>
@@ -391,6 +400,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI><b>CmSummary            </b> - alarm 'AlarmEventDeadlock' if we had any deadlocks... (within a MovingAverage over 10 minutes) </LI>
 		<LI><b>CmSummary            </b> - new chart 'MemoryPressure' -- Memory Pressure, with columns 'osMem_system_high_memory_signal_state', 'osMem_system_low_memory_signal_state', 'memProcessPhysicalMemoryLow', 'memProcessVirtualMemoryLow' </LI>
 		<LI><b>CmSummary            </b> - for some columns 'io_total_read', 'io_total_write', 'pack_received' 'pack_sent', 'packet_errors' -- Set negative counters to 0 </LI>
+		<LI><b>CmSummary            </b> - Alarm 'AlarmEventOutOfWorkerThreads' -- adding some charts from 'CmWaitStats'</LI>
 
 		<LI><b>CmTempdbSpidUsage    </b> - added new column 'context_info_str' which is a String interpretation of the binary field 'context_info'</LI>
 		<LI><b>CmTempdbSpidUsage    </b> - in AlarmEventTempdbSpidUsage also include information from CmActiveStatements</LI>
@@ -456,6 +466,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI><b>CmPgActivity         </b> - Added graph for: Parallel Execution Usage</LI>
 		<LI><b>CmPgActivity         </b> - New column 'worker_count', which counts number of worker thread for the 'leader_pid'</LI>
 		<LI><b>CmPgActivity         </b> - For Parallel Workers, Sort/Group the rows with LeaderPid first, the the WorkerPid (workers are also marked with beige color)</LI>
+		<LI><b>CmPgActivity         </b> - Columns 'execTimeInMs' and 'xactTimeInMs' is now of datatype bigint (long running statements may "overflow" an int value)</LI>
 
 		<LI><b>CmPgArchive          </b> - When 'archived_mb_last_hour' is greater than 10240 MB (10 GB) then raise AlarmEventPgArchiveRate (property 'CmPgArchive.alarm.system.if.archived_mb_last_hour.gt=##')</LI>
 
@@ -477,6 +488,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI><b>CmPgProgVacuum       </b> - new Collector -- Whenever VACUUM is running, the pg_stat_progress_vacuum view will contain one row for each backend (including autovacuum worker processes) that is currently vacuuming.  Progress for VACUUM FULL commands is reported via pg_stat_progress_cluster because both VACUUM FULL and CLUSTER rewrite the table, while regular VACUUM only modifies it in place</LI>
 
 		<LI><b>CmPgReplication      </b> - Changed the "tab name" from 'Replication' to 'Rep Stats', and created a new Group Tab to hold every CM with Replication</LI>
+		<LI><b>CmPgReplication      </b> - Update a "dummy table" (postgrestune_ha_dummy_update) every # minute to induce transaction activity (this can be disabled with 'CmPgReplication.update.primary=false' or change interval with 'CmPgReplication.update.primary.intervalInSec=##')</LI>
 
 		<LI><b>CmPgRepSlots         </b> - New CM to check 'pg_replication_slots', which raises AlarmEventPgReplicationLag when 'lag_kb' is greater than 100MB (config with: CmPgRepSlots.alarm.system.if.lag_kb.gt)</LI>
 
@@ -558,6 +570,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI>Code Completion (for Postgres do not add *known* schema names, it just clutters the code)</LI>
 		<LI>command 'toparquet' -- a first attempt to writet to Parquet Files  (not implemented yet)</LI>
 		<LI>right click menu -- "Get Foreign Key ***Child*** rows for selected rows(s)"</LI>
+		<LI>right click menu -- "Mark all Words, on Double Click" (note: this needs more work)</LI>
 	</UL>
 	<!-- ~~~end-of-this-tool~~~ -->
 

--- a/src/com/asetune/ui/autocomplete/CompletionProviderAbstractSql.java
+++ b/src/com/asetune/ui/autocomplete/CompletionProviderAbstractSql.java
@@ -5791,11 +5791,26 @@ if (_guiOwner == null)
 	{
 		List<JMenu> list = new ArrayList<>();
 		
+//		list.add(createExtraOptions());
 		list.add(createGenerateSqlMenu());
 		list.add(createGenerateJavaMenu());
 		
 		return list;
 	}
+
+//	public JMenu createExtraOptions()
+//	{
+//		JMenu top = new JMenu("Editor Options");
+//
+////		JMenuItem markAllTextOnDoubleClick = new JCheckBoxMenuItem("Double Click, mark all Occurrences");
+//		JMenuItem markAllTextOnDoubleClick = new JCheckBoxMenuItem(new MarkOccurencesAction("Double Click, mark all Occurrences"));
+//		
+//		
+//		top.add(markAllTextOnDoubleClick);
+//		
+//		return top;
+//	}
+	
 
 	/*----------------------------------------------------------------------
 	**----------------------------------------------------------------------
@@ -6262,6 +6277,34 @@ if (_guiOwner == null)
 	/*----------------------------------------------------------------------
 	** END: Generate SQL Menu
 	**----------------------------------------------------------------------*/ 	
+	
+//	private class MarkOccurencesAction extends TextAction
+//	{
+//		private static final long serialVersionUID = 1L;
+//
+//		public MarkOccurencesAction(String name)
+//		{
+//			super(name);
+//		}
+//
+//		@Override
+//		public void actionPerformed(ActionEvent e)
+//		{
+//			JTextComponent textComp = getTextComponent(e);
+//
+//			System.out.println("MarkOccurencesAction: actionPerformed(): e.getSource()=" + e.getSource());
+//			System.out.println("MarkOccurencesAction: actionPerformed(): e=" + e);
+//
+//			if (textComp instanceof RSyntaxTextAreaX)
+//			{
+//				System.out.println("MarkOccurencesAction: --- IS -- RSyntaxTextAreaXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+//				RSyntaxTextAreaX rta = (RSyntaxTextAreaX) textComp;
+////				rta.setHiglightWordModeEnabled();
+//				System.out.println("MarkOccurencesAction: --- setHiglightWordModeEnabled()=" + rta.isHiglightWordModeEnabled());
+//			}
+//		}
+//	}
+	
 }
 
 

--- a/src/com/asetune/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitX.java
+++ b/src/com/asetune/ui/rsyntaxtextarea/RSyntaxTextAreaEditorKitX.java
@@ -211,7 +211,35 @@ public class RSyntaxTextAreaEditorKitX
 	}
 
 	/**
-	 * to uppercase
+	 * Enable Disable "mark words" on double click
+	 */
+	@SuppressWarnings("serial")
+	public static class MarkWordOnDoubleClickAction extends RecordableTextAction
+	{
+		protected MarkWordOnDoubleClickAction(String name)
+		{
+			super(name);
+		}
+
+		@Override
+		public void actionPerformedImpl(ActionEvent e, RTextArea textArea)
+		{
+			RSyntaxTextArea syntaxTextArea = (textArea instanceof RSyntaxTextArea) ? (RSyntaxTextArea) textArea : null;
+			if (syntaxTextArea != null)
+			{
+				RSyntaxTextAreaX.setHiglightWordModeEnabled(syntaxTextArea, ! RSyntaxTextAreaX.isHiglightWordModeEnabled(syntaxTextArea) );
+			}
+		}
+
+		@Override
+		public final String getMacroID()
+		{
+			return getName();
+		}
+	}
+
+	/**
+	 * Format SQL
 	 */
 	@SuppressWarnings("serial")
 	public static class FormatSqlAction extends RecordableTextAction

--- a/src/com/asetune/ui/rsyntaxtextarea/RSyntaxUtilitiesX.java
+++ b/src/com/asetune/ui/rsyntaxtextarea/RSyntaxUtilitiesX.java
@@ -135,12 +135,31 @@ public class RSyntaxUtilitiesX
 		menu.addSeparator();
 
 		//--------------------------------
+		// Mark Text on Double Click
+		if (syntaxTextArea != null)
+		{
+			mi = new JCheckBoxMenuItem(new RSyntaxTextAreaEditorKitX.MarkWordOnDoubleClickAction(RSyntaxTextAreaX.markAllWordsOnDoubleClick));
+			mi.setText("Mark all Words, on Double Click");
+//			mi = new JCheckBoxMenuItem("Mark all Words, on Double Click", RSyntaxTextAreaX.isHiglightWordModeEnabled(syntaxTextArea));
+			mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+//			mi.addActionListener(new ActionListener()
+//			{
+//				@Override
+//				public void actionPerformed(ActionEvent e)
+//				{
+//					RSyntaxTextAreaX.setHiglightWordModeEnabled(syntaxTextArea, ! RSyntaxTextAreaX.isHiglightWordModeEnabled(syntaxTextArea) );
+//				}
+//			});
+			menu.add(mi);
+		}
+
+		//--------------------------------
 		// Format SQL
 		mi = new JMenuItem(new RSyntaxTextAreaEditorKitX.FormatSqlAction(RSyntaxTextAreaX.formatSql));
 		mi.setText("Format SQL");
 		mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | InputEvent.SHIFT_DOWN_MASK));
 		menu.add(mi);
-
+		
 		//--------------------------------
 		// Change Case
 		m = new JMenu("Change Case");

--- a/src/com/asetune/ui/rsyntaxtextarea/TextEditorPaneX.java
+++ b/src/com/asetune/ui/rsyntaxtextarea/TextEditorPaneX.java
@@ -70,10 +70,11 @@ public class TextEditorPaneX extends TextEditorPane
 
 
 
-    public static final String formatSql   = "format-sql";
-    public static final String toUpperCase = "to-upper-case";
-    public static final String toLowerCase = "to-lower-case";
+//    public static final String formatSql   = "format-sql";
+//    public static final String toUpperCase = "to-upper-case";
+//    public static final String toLowerCase = "to-lower-case";
 
+	
     /**
 	 * initialize this class
 	 */


### PR DESCRIPTION
Generic:
 * CmOsDiskSpace -- On Windows add the 'disk label' to the 'drive name' for easier determination of what the disk may be used for
 * CmOsIostat    -- On Windows add the 'disk label' to the 'drive name' for easier determination of what the disk may be used for

SqlServerTune
 * DbmsObjectIdCache -- on "Msg 208, Text='Invalid object name 'xxxx'.'" simply clear the cache for that dbid
 * UserDefinedTimelineChart -- new option: onlyLevelZero={true|false} to only show "top" levels for 'SQL Agent Jobs'
 * CmActiveStatements -- Added column 'tran_begin_time' -- If we have a long running statement we may also want to see the 'tran_begin_time'
 * CmActiveStatements -- Changed logic for 'getLockSummaryForSpid', to handle timeouts in another way
 * CmDatabases        -- On Windows add the 'disk label' to the 'drive name' for easier determination of what the disk may be used for
 * CmDatabases        -- Changed logic for 'getLockSummaryForSpid', to handle timeouts in another way
 * CmOpenTransactions -- Changed logic for 'getLockSummaryForSpid', to handle timeouts in another way
 * CmSummary          -- Alarm 'AlarmEventOutOfWorkerThreads' -- adding some charts from 'CmWaitStats'

PostgresTune
 * CmPgActivity -- 'execTimeInMs' and 'xactTimeInMs' is now of datatype bigint (long running statements may "overflow" an int value)
 * CmPgReplication -- Update a "dummy table" (postgrestune_ha_dummy_update) every # minute to induce transaction activity (this can be disabled with 'CmPgReplication.update.primary=false' or change interval with 'CmPgReplication.update.primary.intervalInSec=##')

SqlWindow
 * added option "Mark all Words, on Double Click" on the context menu (note: this needs more work)