### PR TITLE
Minor fixes

### DIFF
--- a/src/com/asetune/Version.java
+++ b/src/com/asetune/Version.java
@@ -31,10 +31,10 @@ public class Version
 {
 	public static       String PRODUCT_STRING     = "AseTune";      // Do not have spaces etc in this one
 //	public static final String VERSION_STRING     = "4.5.0";        // Use this for public releases
-	public static final String VERSION_STRING     = "4.5.0.88.dev"; // Use this for early releases
-	public static final String BUILD_STRING       = "2024-11-25/build 538";
+	public static final String VERSION_STRING     = "4.5.0.89.dev"; // Use this for early releases
+	public static final String BUILD_STRING       = "2024-12-02/build 539";
 
-	public static final String GIT_DATE_STRING    = "2024-11-25";  // try to update this
+	public static final String GIT_DATE_STRING    = "2024-12-02";  // try to update this
 	public static final String GIT_REVISION_STR   = "600";         // used by CheckForUpdates --- update this on every check-in (emulates Subversion "Revision:" tag)
 
 	public static final boolean IS_DEVELOPMENT_VERSION  = true; // if true: date expiration will be checked on startup

--- a/src/com/asetune/alarm/events/AlarmEventFullTranLog.java
+++ b/src/com/asetune/alarm/events/AlarmEventFullTranLog.java
@@ -89,7 +89,15 @@ extends AlarmEvent
 		// Set: Time To Live if postpone is enabled
 		setTimeToLive(cm);
 
-		// Set the raw data carier: current cpu usage
+		// When message is ErrorNumber=7413 -- Message=|1 task(s) are sleeping waiting for space to become available in the segment 'logsegment' for database 'xxx'.|
+		// This message is repeated every minute (or so)... (and if we are sampling every 30 seconds, we will get a LOT of CANCEL/RAISE messages) 
+		// So set the TimeToLive to 2 minutes
+		long minTtl = 2 * 60 * 1000;
+		long ttl = getTimeToLive();
+		if (ttl < minTtl)
+			setTimeToLive(minTtl);
+
+		// Set the raw data carrier
 		setData(dbname);
 	}
 }

--- a/src/com/asetune/cm/ase/CmActiveStatements.java
+++ b/src/com/asetune/cm/ase/CmActiveStatements.java
@@ -1555,7 +1555,7 @@ extends CountersModel
 												extendedDescHtml += "<br><br>" + cmProcessActivity.toHtmlTableString(DATA_ABS, blockedSpidRowId, true, false, false);
 
 												// Get 'LastKnownSqlText'
-												if (true)
+												if (true && PersistentCounterHandler.hasInstance() )
 												{
 													ISqlCaptureBroker sqlCaptureBroker = PersistentCounterHandler.getInstance().getSqlCaptureBroker();
 													if (sqlCaptureBroker != null && sqlCaptureBroker instanceof SqlCaptureBrokerAse)

--- a/src/com/asetune/cm/ase/CmErrorLog.java
+++ b/src/com/asetune/cm/ase/CmErrorLog.java
@@ -380,7 +380,7 @@ extends CountersModelAppend
 					String extendedDescHtml = ErrorMessage;
 
 					// Try to copy everything between "database" and a dot (".")
-					String dbname = StringUtils.substringBetween(ErrorMessage, "database", ".");
+					String dbname = StringUtils.substringBetween(ErrorMessage, "database '", "'.");
 					// Strip out chars we do not need or want
 					if (StringUtil.hasValue(dbname))
 						dbname = dbname.replace('\'', ' ').replace('.', ' ').trim();

--- a/src/com/asetune/cm/ase/CmOpenDatabases.java
+++ b/src/com/asetune/cm/ase/CmOpenDatabases.java
@@ -1832,7 +1832,7 @@ extends CountersModel
 
 							// Get 'LastKnownSqlText'
 							boolean getLastKnownSqlText = true;
-							if (getLastKnownSqlText)
+							if (getLastKnownSqlText && PersistentCounterHandler.hasInstance())
 							{
 								ISqlCaptureBroker sqlCaptureBroker = PersistentCounterHandler.getInstance().getSqlCaptureBroker();
 								if (sqlCaptureBroker != null && sqlCaptureBroker instanceof SqlCaptureBrokerAse)

--- a/src/com/asetune/cm/ase/CmSummary.java
+++ b/src/com/asetune/cm/ase/CmSummary.java
@@ -1458,7 +1458,7 @@ extends CmSummaryAbstract
 
 					// Get 'LastKnownSqlText'
 					boolean getLastKnownSqlText = true;
-					if (getLastKnownSqlText)
+					if (getLastKnownSqlText && PersistentCounterHandler.hasInstance())
 					{
 						ISqlCaptureBroker sqlCaptureBroker = PersistentCounterHandler.getInstance().getSqlCaptureBroker();
 						if (sqlCaptureBroker != null && sqlCaptureBroker instanceof SqlCaptureBrokerAse)
@@ -1568,7 +1568,7 @@ extends CmSummaryAbstract
 						
 						// Get 'LastKnownSqlText'
 						boolean getLastKnownSqlText = true;
-						if (getLastKnownSqlText)
+						if (getLastKnownSqlText && PersistentCounterHandler.hasInstance())
 						{
 							ISqlCaptureBroker sqlCaptureBroker = PersistentCounterHandler.getInstance().getSqlCaptureBroker();
 							if (sqlCaptureBroker != null && sqlCaptureBroker instanceof SqlCaptureBrokerAse)

--- a/src/com/asetune/cm/ase/ToolTipSupplierAse.java
+++ b/src/com/asetune/cm/ase/ToolTipSupplierAse.java
@@ -139,7 +139,7 @@ extends CmToolTipSupplierDefault
 						{
 							String tabOwnerName = AseConnectionUtils.getObjectOwner(conn, dbName, tabObjId);
 							
-							List<Completion> list = _complProvider.getTableListWithGuiProgress(conn, dbName, tabOwnerName, objectName);
+							List<Completion> list = _complProvider.getTableListWithGuiProgress(conn, dbName, tabOwnerName, objectName, false);
 
 							if (_logger.isDebugEnabled())
 								_logger.debug("ToolTipSupplierAse.getToolTipTextOnTableCell(ObjectName): dbName='"+dbName+"', ownerName='"+tabOwnerName+"', objectName='"+objectName+"', cm='"+_cm.getName()+"'. list.size()="+(list==null?"-null-":list.size())+".");

--- a/src/com/asetune/cm/sqlserver/CmActiveStatements.java
+++ b/src/com/asetune/cm/sqlserver/CmActiveStatements.java
@@ -1856,7 +1856,7 @@ System.out.println("Can't find the position for columns ('sql_handle'="+pos_sql_
 
 		sb.append("<TABLE BORDER=1 class='dbx-table-basic'>\n");
 //		sb.append("  <TR> <TH>Blocked SPID</TH> <TH>MonSqlText</TH> <TH>LockInfo</TH> <TH>XML Showplan</TH> </TR>\n");
-		sb.append("  <TR> <TH>Blocked SPID</TH> <TH>MonSqlText</TH> <TH>LockInfo</TH> </TR>\n");
+		sb.append("  <TR> <TH>Blocked SPID</TH> <TH>MonSqlText</TH> <TH>LockInfo</TH> <TH>ExtraInfo</TH> </TR>\n");
 		
 		int addCount = 0;
 		
@@ -1883,6 +1883,36 @@ System.out.println("Can't find the position for columns ('sql_handle'="+pos_sql_
 				String lockInfo   = o_lockInfo   == null ? "" : o_lockInfo  .toString();
 //				String liveQp     = o_liveQp     == null ? "" : o_liveQp    .toString();
 //				String showplan   = o_showplan   == null ? "" : o_showplan  .toString();
+
+				// Get extra info in 1 cell:
+				//  - login_name 
+				//  - command 
+				//  - tran_begin_time
+				//  - tran_name 
+				//  - ProcName 
+				//  - HOST_NAME 
+				//  - SpidLockCount 
+				//  - database_name 
+				//  - program_name 
+				//  - context_info_str 
+				//  - wait_time 
+				//  - wait_resource 
+				String extraInfo = "<TABLE BORDER=0 CELLSPACING=0 CELLPADDING=1 class='dbx-table-basic'>";
+				if (counters.findColumn("login_name")       != -1) extraInfo += "<TR> <TD><B>login_name      </B></TD> <TD>" + counters.getValueAsString(rowId, "login_name"      ) + "</TD> </TR>";
+				if (counters.findColumn("program_name")     != -1) extraInfo += "<TR> <TD><B>program_name    </B></TD> <TD>" + counters.getValueAsString(rowId, "program_name"    ) + "</TD> </TR>";
+				if (counters.findColumn("context_info_str") != -1) extraInfo += "<TR> <TD><B>context_info_str</B></TD> <TD>" + counters.getValueAsString(rowId, "context_info_str") + "</TD> </TR>";
+				if (counters.findColumn("HOST_NAME")        != -1) extraInfo += "<TR> <TD><B>HOST_NAME       </B></TD> <TD>" + counters.getValueAsString(rowId, "HOST_NAME"       ) + "</TD> </TR>";
+				if (counters.findColumn("ProcName")         != -1) extraInfo += "<TR> <TD><B>ProcName        </B></TD> <TD>" + counters.getValueAsString(rowId, "ProcName"        ) + "</TD> </TR>";
+
+				if (counters.findColumn("command")          != -1) extraInfo += "<TR> <TD><B>command         </B></TD> <TD>" + counters.getValueAsString(rowId, "command"         ) + "</TD> </TR>";
+				if (counters.findColumn("tran_begin_time")  != -1) extraInfo += "<TR> <TD><B>tran_begin_time </B></TD> <TD>" + counters.getValueAsString(rowId, "tran_begin_time" ) + "</TD> </TR>";
+				if (counters.findColumn("tran_name")        != -1) extraInfo += "<TR> <TD><B>tran_name       </B></TD> <TD>" + counters.getValueAsString(rowId, "tran_name"       ) + "</TD> </TR>";
+				if (counters.findColumn("SpidLockCount")    != -1) extraInfo += "<TR> <TD><B>SpidLockCount   </B></TD> <TD>" + counters.getValueAsString(rowId, "SpidLockCount"   ) + "</TD> </TR>";
+				if (counters.findColumn("database_name")    != -1) extraInfo += "<TR> <TD><B>database_name   </B></TD> <TD>" + counters.getValueAsString(rowId, "database_name"   ) + "</TD> </TR>";
+				if (counters.findColumn("wait_time")        != -1) extraInfo += "<TR> <TD><B>wait_time       </B></TD> <TD>" + counters.getValueAsString(rowId, "wait_time"       ) + "</TD> </TR>";
+				if (counters.findColumn("wait_resource")    != -1) extraInfo += "<TR> <TD><B>wait_resource   </B></TD> <TD>" + counters.getValueAsString(rowId, "wait_resource"   ) + "</TD> </TR>";
+				extraInfo += "</TABLE>\n";
+				
 
 //				// Prefer a LIVE Plan before a "long" XML Plan
 //				String finalShowPlan = showplan;
@@ -1916,6 +1946,7 @@ System.out.println("Can't find the position for columns ('sql_handle'="+pos_sql_
 				sb.append("    <TD><B>")  .append(blockedSpid  ).append("</B></TD>\n");
 				sb.append("    <TD>"   )  .append(monSqlText   ).append("</TD>\n");
 				sb.append("    <TD>"   )  .append(lockInfo     ).append("</TD>\n");
+				sb.append("    <TD>"   )  .append(extraInfo    ).append("</TD>\n");
 //				sb.append("    <TD><xmp>").append(showplan     ).append("</xmp></TD>\n");
 //				sb.append("    <TD><xmp>").append(finalShowPlan).append("</xmp></TD>\n");
 				sb.append("  </TR>\n");

--- a/src/com/asetune/cm/sqlserver/CmPerfCounters.java
+++ b/src/com/asetune/cm/sqlserver/CmPerfCounters.java
@@ -2458,6 +2458,27 @@ extends CountersModel
 			tgdp.setDataPoint(this.getTimestamp(), larr, darr);
 		}
 
+//		// -----------------------------------------------------------------------------------------
+//		if (GRAPH_NAME_XXX.equals(tgdp.getName()))
+//		{
+//			// +---------------------+------------------------------+------------------------+----------+-----------+
+//			// |object_name          |counter_name                  |instance_name           |cntr_value|cntr_type  |
+//			// +---------------------+------------------------------+------------------------+----------+-----------+
+//			// |:Memory Broker Clerks|Internal benefit              |Buffer Pool             |         0|     65 792|
+//			// |:Memory Broker Clerks|Internal benefit              |Column store object pool|         0|     65 792|
+//			// |:Memory Broker Clerks|Memory broker clerk size      |Buffer Pool             | 8 143 501|     65 792|
+//			// |:Memory Broker Clerks|Memory broker clerk size      |Column store object pool|     2 652|     65 792|
+//			// |:Memory Broker Clerks|Periodic evictions (pages)    |Buffer Pool             |         0|     65 792|
+//			// |:Memory Broker Clerks|Periodic evictions (pages)    |Column store object pool|         0|     65 792|
+//			// |:Memory Broker Clerks|Pressure evictions (pages/sec)|Buffer Pool             |         0|272 696 576|
+//			// |:Memory Broker Clerks|Pressure evictions (pages/sec)|Column store object pool|15 050 839|272 696 576|
+//			// |:Memory Broker Clerks|Simulation benefit            |Buffer Pool             |         0|     65 792|
+//			// |:Memory Broker Clerks|Simulation benefit            |Column store object pool|         0|     65 792|
+//			// |:Memory Broker Clerks|Simulation size               |Buffer Pool             | 2 033 627|     65 792|
+//			// |:Memory Broker Clerks|Simulation size               |Column store object pool|       150|     65 792|
+//			// +------------------------------+------------------------------+------------------------+----------+-----------+
+//		}
+		
 		// -----------------------------------------------------------------------------------------
 		if (GRAPH_NAME_COLUMNSTORE_ALL.equals(tgdp.getName()))
 		{

--- a/src/com/asetune/cm/sqlserver/ToolTipSupplierSqlServer.java
+++ b/src/com/asetune/cm/sqlserver/ToolTipSupplierSqlServer.java
@@ -117,7 +117,7 @@ extends CmToolTipSupplierDefault
 					if (StringUtil.isNullOrBlank(tabOwnerName))
 						tabOwnerName = getObjectSchema(conn, dbName, objectName);
 					
-					List<Completion> list = _complProvider.getTableListWithGuiProgress(conn, dbName, tabOwnerName, objectName);
+					List<Completion> list = _complProvider.getTableListWithGuiProgress(conn, dbName, tabOwnerName, objectName, false);
 
 					if (_logger.isDebugEnabled())
 						_logger.debug("ToolTipSupplierSqlServer.getToolTipTextOnTableCell(ObjectName): dbName='"+dbName+"', ownerName='"+tabOwnerName+"', objectName='"+objectName+"', cm='"+_cm.getName()+"'. list.size()="+(list==null?"-null-":list.size())+".");

--- a/src/com/asetune/cm/sqlserver/gui/CmActiveStatementsPanel.java
+++ b/src/com/asetune/cm/sqlserver/gui/CmActiveStatementsPanel.java
@@ -40,6 +40,7 @@ import com.asetune.graph.TrendGraphColors;
 import com.asetune.gui.ChangeToJTabDialog;
 import com.asetune.gui.TabularCntrPanel;
 import com.asetune.utils.Configuration;
+import com.asetune.utils.StringUtil;
 import com.asetune.utils.SwingUtils;
 
 import net.miginfocom.swing.MigLayout;
@@ -101,11 +102,14 @@ extends TabularCntrPanel
 			@Override
 			public boolean isHighlighted(Component renderer, ComponentAdapter adapter)
 			{
-				String memory_grant_wait_time_ms = adapter.getString(adapter.getColumnIndex("memory_grant_wait_time_ms"));
-				if (memory_grant_wait_time_ms != null)
-					memory_grant_wait_time_ms = memory_grant_wait_time_ms.trim();
-				if ( ! "0".equals(memory_grant_wait_time_ms))
-					return true;
+				String memory_grant_wait_time_ms__str = adapter.getString(adapter.getColumnIndex("memory_grant_wait_time_ms"));
+				if (memory_grant_wait_time_ms__str != null)
+				{
+					memory_grant_wait_time_ms__str = memory_grant_wait_time_ms__str.trim();
+					int memory_grant_wait_time_ms = StringUtil.parseInt(memory_grant_wait_time_ms__str, -1);
+					if (memory_grant_wait_time_ms > 0)
+						return true;
+				}
 				return false;
 			}
 		}, SwingUtils.parseColor(colorStr, TrendGraphColors.LIGHT_BLUE), null));

--- a/src/com/asetune/gui/ResultSetTableModel.java
+++ b/src/com/asetune/gui/ResultSetTableModel.java
@@ -453,17 +453,26 @@ public class ResultSetTableModel
 		//---------------------------------------------------
 
 		//---------------------------------------------------
-		// Special thing for SQL-Server and if noData==true && it's a ResultSet from 'set statistics profile on'
-		// Then we still want to show the output from 'set statistics profile on'
-		if (noData && _rsmdColumnLabel.size() >= 5)
+		// Special thing for SQL-Server and if noData==true && it's a ResultSet from 'set statistics profile/XML on'
+		if (noData)
 		{
+			// Then we still want to show the output from 'set statistics profile on'
 			// The ResultSet always starts with columns: Rows, Executes, StmtText, StmtId, NodeId
-			if (    "Rows"    .equals(_rsmdColumnLabel.get(0))
+			if (    _rsmdColumnLabel.size() >= 5
+			     && "Rows"    .equals(_rsmdColumnLabel.get(0))
 			     && "Executes".equals(_rsmdColumnLabel.get(1))
 			     && "StmtText".equals(_rsmdColumnLabel.get(2))
 			     && "StmtId"  .equals(_rsmdColumnLabel.get(3))
 			     && "NodeId"  .equals(_rsmdColumnLabel.get(4))
 			   )
+			{
+				noData = false;
+			}
+
+			//---------------------------------------------------
+			// If the column name is 'Microsoft SQL Server 2005 XML Showplan'
+			// Then we still want to show the output from 'set statistics XML on'
+			if (_rsmdColumnLabel.size() == 1 && "Microsoft SQL Server 2005 XML Showplan".equals(_rsmdColumnLabel.get(0)))
 			{
 				noData = false;
 			}

--- a/src/com/asetune/history.html
+++ b/src/com/asetune/history.html
@@ -399,6 +399,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI><b>CmActiveStatements   </b> - Added column 'wal_record_count', 'wal_kb_used' to see how much WAL (Write Ahead Log or Transaction log) is used by any DML opterations.</LI>
 		<LI><b>CmActiveStatements   </b> - Added column 'estimated_compl_time_dhms', which will display in '#days #hours #minutes #seconds' until the command is completed</LI>
 		<LI><b>CmActiveStatements   </b> - Added some output to tooltip on 'wait info' (like: 'dop' and 'WaitTimePct')</LI>
+		<LI><b>CmActiveStatements   </b> - Blocking Lock's... Adding more info to 'BlockedSpidsInfo'. ExtraInfo: login_name, program_name, context_info_str, HOST_NAME, ProcName, command, tran_begin_time, tran_name, SpidLockCount, database_name, wait_time, wait_resource</LI>
 		
 		<LI><b>CmAlwaysOn           </b> - Performance enhancement</LI>
 
@@ -654,6 +655,11 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 		<LI>For SQL Server: Code Completion -- Summary Information -- Did not show indexes for COLUMNSSTORE Indexes</LI>
 		<LI>For Postgres:  Code Completion -- Summary Information -- Did not show an accurate INCLUDE list for indexes</LI>
 		<LI>A better implementation of 'Generate INSERT' for ResultSet selected rows</LI>
+		<LI>in 'go nodata' option: Still present 'XML Showplan'</LI>
+		<LI>RepServer: new "RCL command" -- alter connection to ${selectedText} set dsi_log_cmds to 'on/off'</LI>
+		<LI>Tooltip on ResultSet tables, added "object lookup" on column name 'objectname|object_name|object name|tablename|table_name|table name'.<br>
+		    AND: If columns 'dbname|databasename|database_name|database name' and 'schemaname|schema_name|schema name' exists the will be used to "fully qualify" the objectname</LI>
+		<LI></LI>
 	</UL>
 	<!-- ~~~end-of-this-tool~~~ -->
 

--- a/src/com/asetune/tools/sqlw/QueryWindow.java
+++ b/src/com/asetune/tools/sqlw/QueryWindow.java
@@ -13781,6 +13781,8 @@ checkPanelSize(_resPanel, comp);
 		commandList.add(new FavoriteCommandEntry(VendorType.RS, "trace 'off', 'dsi', 'dsi_buf_dump'", "", "Turn OFF: Write SQL statements executed by the DSI Threads to the RS log"));
 		commandList.add(new FavoriteCommandEntry(VendorType.RS, "alter connection to ${selectedText} set trace to 'econn, dsi_buf_dump, on'",  "", "Turn ON: dsi_buf_dump for ExpressConnect"));
 		commandList.add(new FavoriteCommandEntry(VendorType.RS, "alter connection to ${selectedText} set trace to 'econn, dsi_buf_dump, off'", "", "Turn OFF: dsi_buf_dump for ExpressConnect"));
+		commandList.add(new FavoriteCommandEntry(VendorType.RS, "alter connection to ${selectedText} set dsi_log_cmds to 'on'",  "", "Turn ON: dsi_log_cmds for a Connection (log failed/skipped trans to the RS log)"));
+		commandList.add(new FavoriteCommandEntry(VendorType.RS, "alter connection to ${selectedText} set dsi_log_cmds to 'off'", "", "Turn OFF: dsi_log_cmds for a Connection (log failed/skipped trans to the RS log)"));
 
 		commandList.add(FavoriteCommandEntry.addSeparator());
 		

--- a/src/com/asetune/ui/autocomplete/CompletionProviderAse.java
+++ b/src/com/asetune/ui/autocomplete/CompletionProviderAse.java
@@ -1079,10 +1079,10 @@ extends CompletionProviderAbstractSql
 	protected List<ProcedureInfo> refreshCompletionForProcedures(Connection conn, WaitForExecDialog waitDialog)
 	throws SQLException
 	{
-		return refreshCompletionForProcedures(conn, waitDialog, null, null, null);
+		return refreshCompletionForProcedures(conn, waitDialog, null, null, null, isWildcatdMath());
 	}
 	@Override
-	protected List<ProcedureInfo> refreshCompletionForProcedures(Connection conn, WaitForExecDialog waitDialog, String catalogName, String schemaName, String procName)
+	protected List<ProcedureInfo> refreshCompletionForProcedures(Connection conn, WaitForExecDialog waitDialog, String catalogName, String schemaName, String procName, boolean wildcardSearch)
 	throws SQLException
 	{
 //System.out.println("ASE: refreshCompletionForProcedures()");
@@ -1114,7 +1114,8 @@ extends CompletionProviderAbstractSql
 		else
 		{
 			procName = procName.replace('*', '%').trim();
-			if ( ! procName.endsWith("%") )
+//			if ( ! procName.endsWith("%") )
+			if (wildcardSearch && ! procName.endsWith("%") )
 				procName += "%";
 			procName = " and name like '"+procName+"'";
 		}


### PR DESCRIPTION

AseTune
 * Bugfix: Full Transaction log, error: 7413 - # task(s) are sleeping waiting for space) is issued every minute (but if we sample at 30 second, we will RASE/CANCEL the alarm to often... Raised TimeToLive to 2 minutes
 * Bugfix: Only get "Last Known SQL Texts" if we do recordings...

SqlServerTune
 * CmActiveStatements -- Blocking Lock's... Adding more info to 'BlockedSpidsInfo'. ExtraInfo: login_name, program_name, context_info_str, HOST_NAME, ProcName, command, tran_begin_time, tran_name, SpidLockCount, database_name, wait_time, wait_resource
 * CmActiveStatements -- GUI the background color for 'waitingForMemoryGrant' was sometimes triggered faulty.

SqlWindow:
 * in 'go nodata' option: Still present 'XML Showplan'
 * RepServer: new "RCL command" -- alter connection to ${selectedText} set dsi_log_cmds to 'on/off'
 * Tooltip on ResultSet tables, added "object lookup" on column name 'objectname|object_name|object name|tablename|table_name|table name'.
   AND: If columns 'dbname|databasename|database_name|database name' and 'schemaname|schema_name|schema name' exists the will be used to "fully qualify" the objectname
 * Also added "non wildcard" searches when doing the above (so we do not get to many "duplicate" lookups)