### PR TITLE
Minor changes

### DIFF
--- a/resources/WebContent/scripts/dbxtune/js/dbxGraphCounterDetails.js
+++ b/resources/WebContent/scripts/dbxtune/js/dbxGraphCounterDetails.js
@@ -27,6 +27,7 @@ var _cmPendingOpenCm = null;
 // Sticky "last viewed" — persisted to localStorage so re-opening after reload returns to the same tab
 var _cmLastGroup    = (function(){ try { return localStorage.getItem('cmDetail-lastGroup') || null; } catch(e) { return null; } }());
 var _cmLastCm       = (function(){ try { return localStorage.getItem('cmDetail-lastCm')    || null; } catch(e) { return null; } }());
+var _cmLastCmPerGroup = (function(){ try { return JSON.parse(localStorage.getItem('cmDetail-lastCmPerGroup') || '{}'); } catch(e) { return {}; } }());
 
 //-----------------------------------------------------------
 // CM DETAIL PANEL
@@ -279,11 +280,14 @@ function cmDetailRenderCms(cms)
 	var $ct = $('#cm-name-tabs').empty();
 	if (!cms || !cms.length) { cmDetailShowMsg('No CMs in this group'); return; }
 
-	// Auto-select: prefer last viewed CM (if present in this group), otherwise first CM with data
+	// Auto-select: prefer per-group last CM, then global last CM, then first CM with data
 	var cmNames = cms.map(function(c) { return c.cmName; });
-	var selCm = (_cmLastCm && cmNames.indexOf(_cmLastCm) >= 0)
-		? _cmLastCm
-		: cms[0].cmName;
+	var perGroupCm = _cmGroup && _cmLastCmPerGroup[_cmGroup];
+	var selCm = (perGroupCm && cmNames.indexOf(perGroupCm) >= 0)
+		? perGroupCm
+		: (_cmLastCm && cmNames.indexOf(_cmLastCm) >= 0)
+			? _cmLastCm
+			: cms[0].cmName;
 	if (selCm === cms[0].cmName && !(_cmLastCm && cmNames.indexOf(_cmLastCm) >= 0)) {
 		// No last-CM match — fall back to first CM with data
 		for (var i = 0; i < cms.length; i++) {
@@ -322,6 +326,10 @@ function cmDetailRenderCms(cms)
 	_cmName  = selCm;
 	_cmLastCm = selCm;
 	try { localStorage.setItem('cmDetail-lastCm', selCm); } catch(e) {}
+	if (_cmGroup) {
+		_cmLastCmPerGroup[_cmGroup] = selCm;
+		try { localStorage.setItem('cmDetail-lastCmPerGroup', JSON.stringify(_cmLastCmPerGroup)); } catch(e) {}
+	}
 	cmTrendGraphsUpdateButton();
 	cmDetailLoadData(_cmSrvName, selCm, _cmTimestamp, _cmType);
 }
@@ -353,6 +361,10 @@ function cmDetailSelectCm(cmName)
 	_cmName = cmName;
 	_cmLastCm = cmName;
 	try { localStorage.setItem('cmDetail-lastCm', cmName); } catch(e) {}
+	if (_cmGroup) {
+		_cmLastCmPerGroup[_cmGroup] = cmName;
+		try { localStorage.setItem('cmDetail-lastCmPerGroup', JSON.stringify(_cmLastCmPerGroup)); } catch(e) {}
+	}
 	// Toggle active class only — no need to re-render the whole tab list
 	$('#cm-name-tabs .nav-link').removeClass('active');
 	$('#cm-name-tabs li[data-cm-name="' + cmName + '"] .nav-link').addClass('active');
@@ -545,14 +557,28 @@ function cmDetailLoadData(srvName, cmName, timestamp, type)
 						return;
 					}
 				}
-				// Postponed CM: no data at this timestamp — re-fetch the latest known sample
-				// so we can display it with the postpone watermark (same path as normal data).
+				// Postponed CM: no data at this timestamp — ask navSample for the exact last
+				// DB timestamp (same source the << prev button uses), then re-fetch with it.
+				// Using navSample avoids two failure modes of r.lastSampleMs: it being 0
+				// (server just restarted) or off by milliseconds (±1s window miss on re-fetch).
 				if (r.error === 'no-data-in-window' && r.postponeEnabled && r.postponeTime > 0
-						&& r.lastSampleMs && r.lastSampleMs > 0 && !_isPostponeFallback) {
+						&& !_isPostponeFallback) {
 					_cmPostponeFallback = true;
-					// Use moment() for local-time string — avoids UTC/local timezone mismatch
-					// that new Date().toISOString() would introduce (server stores local time).
-					cmDetailLoadData(srvName, cmName, moment(r.lastSampleMs).format('YYYY-MM-DD HH:mm:ss'), type);
+					$.ajax({
+						url: '/api/cc/mgt/cm/navSample',
+						data: { srv: srvName, time: timestamp, cm: cmName, dir: 'prev' },
+						dataType: 'json',
+						success: function(nav) {
+							if (nav.found && nav.sampleTime) {
+								cmDetailLoadData(srvName, cmName, nav.sampleTime, type);
+							} else {
+								cmDetailShowMsg(r.message || r.error);
+							}
+						},
+						error: function() {
+							cmDetailShowMsg(r.message || r.error);
+						}
+					});
 					return;
 				}
 				if (r.error) { cmDetailShowMsg(r.message || r.error); return; }

--- a/resources/WebContent/scripts/dbxtune/js/dbxGraphPage.js
+++ b/resources/WebContent/scripts/dbxtune/js/dbxGraphPage.js
@@ -712,6 +712,10 @@
 						}, 600);
 					}
 
+					// Re-acquire the slider element here — the original var was declared in the
+					// early-return branch above and is undefined in this (first-time setup) path.
+					var dbxHistoryTimelineSlider = document.getElementById('dbx-history-timeline-slider');
+
 					// ADD 'input' listener -- when we are moving the slider (without stopping)
 					dbxHistoryTimelineSlider.addEventListener('input', function(event)
 					{

--- a/src/com/dbxtune/AppDir.java
+++ b/src/com/dbxtune/AppDir.java
@@ -184,9 +184,6 @@ public class AppDir
 				{
 					// First CHECK if we can do symbolic links
 					// if NOT: we need to follow the installation requirements -- https://github.com/goranschwarz/DbxTune/blob/master/README_dbxcentral_0_install_windows.md
-					if (startedWith_createAppDir)
-					{
-					}
 					if ( ! testCreateSymbolicLink(dbxUserHome, ps) )
 					{
 						System.out.println();
@@ -198,6 +195,9 @@ public class AppDir
 						throw new RuntimeException("Can't create a 'dummy' Symbolic Link. When installing DbxCentral we NEED to create symbolic links. Follow the Installation Requirements at: https://github.com/goranschwarz/DbxTune/blob/master/README_dbxcentral_0_install_windows.md");
 					}
 
+					if (startedWith_createAppDir)
+					{
+					}
 					dbxcCreated = mkdir(dbxUserHome, "dbxc",                    ps, logList, "- where user/localized DbxCentral files are located...");
 					
 					// Do this up here (if it's version 2019-06-xx since the 'dbxc' dir already exists... and wont be created in below logic
@@ -212,6 +212,9 @@ public class AppDir
 			// Do this up here (if it's version 2019-06-xx since the 'dbxc' dir already exists... and wont be created in below logic
 			dbxcReports = mkdir(dbxUserHome, "dbxc" + sep + "reports",  ps, logList, "- DbxCentral reports created by 'Daily Report', etc.");
 		}
+
+		// Log if we created the DbxCentral directory or not
+		log(ps, logList, "INFO: Created DbxCentral Directory = " + (dbxcCreated != null) +". dbxCentralCreatedDir '" + dbxcCreated + "'.");
 
 		// If the 'dbxc' directory was created
 		if (dbxcCreated != null)
@@ -244,6 +247,7 @@ public class AppDir
 
 					if (isWindows)
 					{
+						log(ps, logList, "DbxCentral for Windows: populating files in the 'bin' directory '" + dbxcBin + "'.");
 //						log(ps, logList, "DbxCentral for Windows does not have any starter files for the moment (not yet implemented for Windows).");
 						
 //FIXME: The Below files do not yet exist
@@ -270,6 +274,8 @@ public class AppDir
 					}
 					else
 					{
+						log(ps, logList, "DbxCentral for Linux/Others: populating files in the 'bin' directory '" + dbxcBin + "'.");
+
 						// It's probably better to make symbilic links from: ${HOME}./dbxtune/dbxc/bin/xxx.sh to ${DBXTUNE_HOME}/bin/xxx.sh 
 						createSymbolicLink(dbxcBinStr + "list_ALL.sh",         dbxHomeBin + "dbxc_list_ALL.sh",  ps, logList, "- Soft link to the DBXTUNE_HOME software install, instead of copy. Easier for new SW releases.");
 						createSymbolicLink(dbxcBinStr + "start_ALL.sh",        dbxHomeBin + "dbxc_start_ALL.sh", ps, logList, "- Soft link to the DBXTUNE_HOME software install, instead of copy. Easier for new SW releases.");
@@ -290,6 +296,8 @@ public class AppDir
 				{
 					String srcDir = dbxHomeResourceDbxcentralScripts + "conf" + sep;
 
+					log(ps, logList, "DbxCentral: populating files in the 'conf' directory '" + dbxcConf + "'.");
+
 					if (isWindows)
 					{
 						copyFileToDir(srcDir + "SERVER_LIST.windows", "SERVER_LIST", dbxcConf, ps, logList, false, "- What Servers should be started/listed/stopped by 'dbxc_{start|list|stop}_ALL.bat'");
@@ -307,6 +315,7 @@ public class AppDir
 					copyFileToDir(srcDir + "mysql.GENERIC.conf",             dbxcConf, ps, logList, "- Example/template Config file for MySQL");
 					copyFileToDir(srcDir + "postgres.GENERIC.conf",          dbxcConf, ps, logList, "- Example/template Config file for Postgres");
 					copyFileToDir(srcDir + "sqlserver.GENERIC.conf",         dbxcConf, ps, logList, "- Example/template Config file for Microsoft SQL-Server");
+					copyFileToDir(srcDir + "oracle.GENERIC.conf",            dbxcConf, ps, logList, "- Example/template Config file for Oracle");
 				}
 
 				// Copy some files to ${DBXTUNE_HOME} if it has a '0' soft-link / pointer

--- a/src/com/dbxtune/CounterControllerAbstract.java
+++ b/src/com/dbxtune/CounterControllerAbstract.java
@@ -325,6 +325,17 @@ implements ICounterController
 		return _CmList; 
 	}
 
+	@Override
+	public List<String> getCmListAsStrings()
+	{
+		List<String> list = new ArrayList<>(_CmList.size());
+		for (CountersModel cm : _CmList)
+		{
+			list.add(cm.getName());
+		}
+		return list; 
+	}
+
 	/** */
 	@Override
 	public void setDefaultSleepTimeInSec(int sleepTime)

--- a/src/com/dbxtune/ICounterController.java
+++ b/src/com/dbxtune/ICounterController.java
@@ -145,6 +145,12 @@ public interface ICounterController
 	 * @return a list of all CM's
 	 */
 	public List<CountersModel> getCmList();
+
+	/** 
+	 * Get a List of all CM's as a List of Strings
+	 * @return a list of all CM's as Strings
+	 */
+	public List<String> getCmListAsStrings();
 	
 	/** 
 	 * Get <code>CountersModel</code> object for a CM that has the "long" name for example 'Procedure Call Stack' for CMprocCallStack

--- a/src/com/dbxtune/Version.java
+++ b/src/com/dbxtune/Version.java
@@ -31,10 +31,10 @@ public class Version
 {
 	public static       String PRODUCT_STRING     = "DbxTune";      // Do not have spaces etc in this one
 //	public static final String VERSION_STRING     = "4.6.0";        // Use this for public releases
-	public static final String VERSION_STRING     = "4.6.0.60.dev"; // Use this for early releases
-	public static final String BUILD_STRING       = "2026-06-26/build 610";
+	public static final String VERSION_STRING     = "4.6.0.61.dev"; // Use this for early releases
+	public static final String BUILD_STRING       = "2026-06-30/build 611";
 
-	public static final String GIT_DATE_STRING    = "2026-06-26";  // try to update this
+	public static final String GIT_DATE_STRING    = "2026-06-30";  // try to update this
 	public static final String GIT_REVISION_STR   = "610";         // used by CheckForUpdates --- update this on every check-in (emulates Subversion "Revision:" tag)
 
 	public static final boolean IS_DEVELOPMENT_VERSION  = true; // if true: date expiration will be checked on startup

--- a/src/com/dbxtune/cm/os/CmOsUtils.java
+++ b/src/com/dbxtune/cm/os/CmOsUtils.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (C) 2010-2019 Goran Schwarz
+ * 
+ * This file is part of DbxTune
+ * DbxTune is a family of sub-products *Tune, hence the Dbx
+ * Here are some of the tools: AseTune, IqTune, RsTune, RaxTune, HanaTune, 
+ *          SqlServerTune, PostgresTune, MySqlTune, MariaDbTune, Db2Tune, ...
+ * 
+ * DbxTune is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * DbxTune is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with DbxTune.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package com.dbxtune.cm.os;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CmOsUtils
+{
+
+	/**
+	 * List all KNOWN CmOs*
+	 * 
+	 * @return
+	 */
+	public static List<String> getCmOsNames()
+	{
+		List<String> names = new ArrayList<>();
+		
+		names.add(CmOsIostat    .class.getSimpleName());
+		names.add(CmOsVmstat    .class.getSimpleName());
+		names.add(CmOsMpstat    .class.getSimpleName());
+		names.add(CmOsUptime    .class.getSimpleName());
+		names.add(CmOsMeminfo   .class.getSimpleName());
+		names.add(CmOsNwInfo    .class.getSimpleName());
+		names.add(CmOsDiskSpace .class.getSimpleName());
+		names.add(CmOsPs        .class.getSimpleName());
+
+		return names;
+	}
+}

--- a/src/com/dbxtune/cm/sqlserver/CmPerfCounters.java
+++ b/src/com/dbxtune/cm/sqlserver/CmPerfCounters.java
@@ -3085,9 +3085,9 @@ extends CountersModel
 		CmSettingsHelper.Type isAlarmSwitch = CmSettingsHelper.Type.IS_ALARM_SWITCH;
 		
 		list.add(new CmSettingsHelper("FreeListStalls",            isAlarmSwitch, PROPKEY_alarm_FreeListStalls      , Double .class, conf.getDoubleProperty(PROPKEY_alarm_FreeListStalls      , DEFAULT_alarm_FreeListStalls      ), DEFAULT_alarm_FreeListStalls      , "If 'Free list stalls/sec' is greater than 0.5 then send 'AlarmEventPerfCounterWarning'." ));
-		list.add(new CmSettingsHelper("FreeListStalls RaiseDelay",                PROPKEY_alarm_FreeListStalls_delay, Integer.class, conf.getDoubleProperty(PROPKEY_alarm_FreeListStalls_delay, DEFAULT_alarm_FreeListStalls_delay), DEFAULT_alarm_FreeListStalls_delay, "If 'Free list stalls/sec' is true and has been so for 2 minutes then proceed with the Alarm Raise." ));
+		list.add(new CmSettingsHelper("FreeListStalls RaiseDelay",                PROPKEY_alarm_FreeListStalls_delay, Integer.class, conf.getIntProperty   (PROPKEY_alarm_FreeListStalls_delay, DEFAULT_alarm_FreeListStalls_delay), DEFAULT_alarm_FreeListStalls_delay, "If 'Free list stalls/sec' is true and has been so for 2 minutes then proceed with the Alarm Raise." ));
 		list.add(new CmSettingsHelper("LazyWrites",                isAlarmSwitch, PROPKEY_alarm_LazyWrites          , Double.class , conf.getDoubleProperty(PROPKEY_alarm_LazyWrites          , DEFAULT_alarm_LazyWrites          ), DEFAULT_alarm_LazyWrites          , "If 'Lazy writes/sec' is greater than 20 then send 'AlarmEventPerfCounterWarning'." ));
-		list.add(new CmSettingsHelper("LazyWrites RaiseDelay",                    PROPKEY_alarm_LazyWrites_delay    , Integer.class, conf.getDoubleProperty(PROPKEY_alarm_LazyWrites_delay    , DEFAULT_alarm_LazyWrites_delay    ), DEFAULT_alarm_LazyWrites_delay    , "If 'Lazy writes/sec' is true and has been so for 3 minutes then proceed with the Alarm Raise." ));
+		list.add(new CmSettingsHelper("LazyWrites RaiseDelay",                    PROPKEY_alarm_LazyWrites_delay    , Integer.class, conf.getIntProperty   (PROPKEY_alarm_LazyWrites_delay    , DEFAULT_alarm_LazyWrites_delay    ), DEFAULT_alarm_LazyWrites_delay    , "If 'Lazy writes/sec' is true and has been so for 3 minutes then proceed with the Alarm Raise." ));
 
 		return list;
 	}

--- a/src/com/dbxtune/gui/MainFrame.java
+++ b/src/com/dbxtune/gui/MainFrame.java
@@ -5373,7 +5373,7 @@ _cmNavigatorPrevStack.addFirst(selectedTabTitle);
 		}
 	}
 	@Override
-	public void pcsConsumeInfo(String persistWriterName, Timestamp sessionStartTime, Timestamp mainSampleTime, int persistTimeInMs, PersistWriterStatistics writerStats)
+	public void pcsConsumeInfo(String persistWriterName, Timestamp sessionStartTime, Timestamp mainSampleTime, int persistTimeInMs, PersistWriterStatistics writerStats, String targetInfo)
 	{
 		_pcsConsumeInfoLastReceived = System.currentTimeMillis();
 		

--- a/src/com/dbxtune/gui/wizard/WizardOffline.java
+++ b/src/com/dbxtune/gui/wizard/WizardOffline.java
@@ -34,6 +34,7 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowEvent;
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
@@ -41,9 +42,12 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.swing.AbstractAction;
 import javax.swing.JFileChooser;
@@ -56,6 +60,7 @@ import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
@@ -64,7 +69,14 @@ import org.netbeans.api.wizard.WizardDisplayer;
 import org.netbeans.spi.wizard.Wizard;
 import org.netbeans.spi.wizard.WizardException;
 import org.netbeans.spi.wizard.WizardPage;
+import org.reflections.Reflections;
 
+import com.dbxtune.AseTune;
+import com.dbxtune.CounterController;
+import com.dbxtune.Version;
+import com.dbxtune.cm.CounterSetTemplates;
+import com.dbxtune.cm.CountersModel;
+import com.dbxtune.cm.os.CmOsUtils;
 import com.dbxtune.gui.MainFrame;
 import com.dbxtune.pcs.PersistWriterJdbc;
 import com.dbxtune.pcs.PersistentCounterHandler;
@@ -73,6 +85,7 @@ import com.dbxtune.ui.rsyntaxtextarea.RSyntaxUtilitiesX;
 import com.dbxtune.utils.Configuration;
 import com.dbxtune.utils.StringUtil;
 import com.dbxtune.utils.SwingUtils;
+import com.dbxtune.utils.TimeUtils;
 
 
 public class WizardOffline
@@ -291,6 +304,7 @@ public class WizardOffline
 //		settings.put("CM.sysMon.test", "testtest");
 
 		boolean previewFile = false;
+		boolean saveAsSorted = false;
 		for (Iterator<String> iterator = settings.keySet().iterator(); iterator.hasNext();)
 		{
 			String key = iterator.next();
@@ -320,6 +334,10 @@ public class WizardOffline
 
 			if(key.startsWith("to-be-discarded.")) // these entries will be discarded
 			{
+				// set preview file
+				if (key.equals("to-be-discarded.saveSorted"))
+					saveAsSorted = val.equalsIgnoreCase("true");
+
 				// set preview file
 				if (key.equals("to-be-discarded.previewFile"))
 					previewFile = val.equalsIgnoreCase("true");
@@ -379,7 +397,8 @@ public class WizardOffline
 				offlineProps.put(key, val);
 			}
 		}
-		offlineProps.save(true);
+//		offlineProps.save(true);
+		String savedFilename = saveFile(offlineProps, saveAsSorted);
 
 		if (_logger.isDebugEnabled())
 			offlineProps.print(System.out, "WizardOffline (after save) offlineProps:");
@@ -391,7 +410,7 @@ public class WizardOffline
 				@Override
 				public void run() 
 				{
-					SimpleFileEditor sfe = new SimpleFileEditor(offlineProps.getFilename());
+					SimpleFileEditor sfe = new SimpleFileEditor(savedFilename);
 					sfe.setVisible(true);
 				}
 			});
@@ -402,7 +421,547 @@ public class WizardOffline
 		return settings;
 	}
 
+	/**
+	 * Save the file somewhere
+	 */
+	private String saveFile(Configuration conf, boolean sortCmByName)
+	{
+//		String savetoFile = conf.getFilename();
+//
+//		// Simply save the file using the default save method in Configuration
+//		conf.save(true);
+//		
+//		return savetoFile;
 
+		return saveFileWithComments(conf, sortCmByName);
+	}
+
+	/**
+	 * Save the file somewhere
+	 */
+	private String saveFileWithComments(Configuration originConf, boolean sortCmByName)
+	{
+		String savetoFile = originConf.getFilename();
+
+		// Take a copy of the input configuration... This will be used to: 
+		//  - copy from
+		//  - print
+		//  - delete the just printed entries
+		// At the end, we just print all the ones that we have not yet handled above
+		
+		Configuration cc = new Configuration();
+//		cc.add(originConf);
+		cc.putAll(originConf);
+		
+		// Get All CmNames from the Configuration (or from CounterCollector)
+		// Get All CmOsNames from the package (scans "com.dbxtune.cm.os" and returns all that starts with CmOs)
+		// The remove all CmOs from the CmList
+		List<String> cmNames   = Collections.emptyList();
+		if (sortCmByName)
+		{
+			cmNames = cc.getUniqueKeys("Cm");
+		}
+		else
+		{
+			cmNames = CounterController.hasInstance() ? CounterController.getInstance().getCmListAsStrings() : cc.getUniqueKeys("Cm");
+		}
+		List<String> cmOsNames = getCmOsNames();
+		cmNames.removeAll(cmOsNames);
+		
+		
+		File f = new File(savetoFile);
+		try (FileOutputStream os = new FileOutputStream(f); BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "8859_1")))
+		{
+			// Write Header
+			String s = originConf.getEmbeddedMessage();
+			writeln(bw, "#======================================================="); 
+			if (s != null)
+			{
+				writeln(bw, "# " + s);
+			}
+			writeln(bw, "# Last save time: " + TimeUtils.toStringYmdHms(System.currentTimeMillis()));
+			writeln(bw, "#-------------------------------------------------------");
+			writeln(bw, "");
+
+			//-----------------------------------------------
+			// Write the different sections
+			//-----------------------------------------------
+
+			// offline.sampleTime
+			
+			// CounterSet.template.default
+
+			// Normal CM's
+			// - First the CM
+			// - Then Settings
+			// - Then alarms
+			
+			// OS Monitor
+			// - First the CM
+			// - Then Settings
+			// - Then alarms
+			
+			// AlarmHandler
+			// AlarmHandler.WriterClass
+			// AlarmWriter*
+			
+			// DailySummaryReport
+			// DailySummaryReport.sender.classname
+			// ReportSender*
+			
+			// PersistentCounterHandler.WriterClass
+			// PersistWriter*
+
+			// OTHER STUFF NOT COVERED IN ABOVE SECTIONS
+			
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "## How many second to sleep between sampling data");
+			writeln(bw, "##---------------------------------------------------------");
+			writeKey(bw, cc, "offline.sampleTime");
+
+
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "## What is the default Counter template to use.");
+			writeln(bw, "## This will be used for future CounterModels that are not yet created.");
+			writeln(bw, "## So if a new CM is part of template 'SMALL|MEDIUM|LARGE|ALL', it will still be created, even if not part of this config file.");
+			writeln(bw, "##---------------------------------------------------------");
+			writeKey(bw, cc, CounterSetTemplates.PROPKEY_templateDefaultName);
+
+
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- BEGIN: DBMS -- Connection Information");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "## Specified with cmd line parameters: -U|--user <user> -P|--passwd <passwd> -S|--server <srvname[:port]>");
+			if (cc.containsKey("conn.dbmsHost"    )) { writeKey(bw, cc, "conn.dbmsHost");     } else { writeln(bw, "#conn.dbmsHost     = xxx"); }
+			if (cc.containsKey("conn.dbmsPort"    )) { writeKey(bw, cc, "conn.dbmsPort");     } else { writeln(bw, "#conn.dbmsPort     = xxx"); }
+			if (cc.containsKey("conn.dbmsUsername")) { writeKey(bw, cc, "conn.dbmsUsername"); } else { writeln(bw, "#conn.dbmsUsername = xxx"); }
+			if (cc.containsKey("conn.dbmsPassword")) { writeKey(bw, cc, "conn.dbmsPassword"); } else { writeln(bw, "#conn.dbmsPassword = xxx"); }
+			writeln(bw, "## NOTE: If no 'conn.dbmsPassword' is specified, the password will be fetched from ${HOME}/.passwd.enc");
+			writeln(bw, "##       which can be maintained using: dbxPasswd.sh or dbxPassword.bat");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- END: DBMS information");
+			writeln(bw, "##---------------------------------------------------------");
+
+
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- BEGIN: OS Monitoring -- Connection Information");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "## Specified with cmd line parameters: -u|--sshUser <user> -p|--sshPasswd <passwd> -s|--sshServer <srvname[:port]> -k|sshKeyFile <keyfile>");
+			if (cc.containsKey("conn.sshHostname")) { writeKey(bw, cc, "conn.sshHostname"); } else { writeln(bw, "#conn.sshHostname = xxx"); }
+			if (cc.containsKey("conn.sshPort"    )) { writeKey(bw, cc, "conn.sshPort");     } else { writeln(bw, "#conn.sshPort     = xxx"); }
+			if (cc.containsKey("conn.sshUsername")) { writeKey(bw, cc, "conn.sshUsername"); } else { writeln(bw, "#conn.sshUsername = xxx"); }
+			if (cc.containsKey("conn.sshPassword")) { writeKey(bw, cc, "conn.sshPassword"); } else { writeln(bw, "#conn.sshPassword = xxx"); }
+			if (cc.containsKey("conn.sskKeyFile" )) { writeKey(bw, cc, "conn.sskKeyFile");  } else { writeln(bw, "#conn.sskKeyFile  = xxx"); }
+			writeln(bw, "## NOTE: If no 'conn.sshPassword' is specified, the password will be fetched from ${HOME}/.passwd.enc");
+			writeln(bw, "##       which can be maintained using: dbxPasswd.sh or dbxPassword.bat");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- END: OS Monitoring information");
+			writeln(bw, "##---------------------------------------------------------");
+
+
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "## Below are all DBMS Counter Models and it's parameters");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "");
+			for (String cmName : cmNames)
+			{
+				writeCmSection(bw, cc, cmName);
+			}
+
+
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "## Below are all OS Counter Models and it's parameters");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "");
+			for (String cmOsName : cmOsNames)
+			{
+				writeCmSection(bw, cc, cmOsName);
+			}
+
+
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- BEGIN: User Defined Counters");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "## User Defined Counters can be created with the GUI: Menu -> Tools -> Create 'User Defined Counter' Wizard... ");
+			// Possibly: implement below to show/write User Defined Counter Models
+			//            - Get All CM's from CounterController
+			//            - Remove any System Provided CM's ( cm.isSystemCm() or starting with "Cm" ) 
+			//            - What's left would be User Defined Counters :)
+			//           But since "no one" (or few) are using them, we can implement this at a later stage
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- END: User Defined Counters");
+			writeln(bw, "##---------------------------------------------------------");
+
+
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- BEGIN: PCS - Persistent Counter Store");
+			writeln(bw, "##---------------------------------------------------------");
+
+			// Remove all 'PersistentCounterHandler.sqlCapture.*' for Collectors that DOES NOT Support that
+			List<String> DbxSuportsSqlCapture = Arrays.asList(new String[] {AseTune.APP_NAME} );
+			if ( ! DbxSuportsSqlCapture.contains(Version.getAppName()) )
+			{
+				List<String> sqlCaptureKeys = cc.getKeys("PersistentCounterHandler.sqlCapture");
+				for (String key : sqlCaptureKeys)
+				{
+					cc.remove(key);
+				}
+			}
+
+			// Get keys and Writers
+			List<String> pcsKeys    = cc.getKeys("PersistentCounterHandler");
+			List<String> pcsWriters = StringUtil.parseCommaStrToList(cc.getProperty("PersistentCounterHandler.WriterClass", ""), true);
+
+			// Write all keys 'PersistentCounterHandler.*'
+			for (String key : pcsKeys)
+			{
+				writeKey(bw, cc, key);
+			}
+			writeln(bw, "");
+
+			// Writers
+			for (String writerKey : pcsWriters)
+			{
+				writerKey = StringUtils.substringAfterLast(writerKey, ".");
+				writeln(bw, "## Writer: " + writerKey + " -------------------------");
+				List<String> writerKeys = cc.getKeys(writerKey);
+				for (String key : writerKeys)
+				{
+					writeKey(bw, cc, key);
+				}
+				writeln(bw, "");
+			}
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- END: PCS - Persistent Counter Store");
+			writeln(bw, "##---------------------------------------------------------");
+
+
+			
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- BEGIN: Fallback mail Properties");
+			writeln(bw, "##---------------------------------------------------------");
+			String[] prefixArr = new String[] {"AlarmWriterToMail", "ReportSenderToMail"};
+			writeMailTemplate(bw, cc, "to"                  , "mail", "someone@acme.com", prefixArr);
+			writeMailTemplate(bw, cc, "from"                , "mail", "dbxtune"         , prefixArr);
+			writeMailTemplate(bw, cc, "smtp.hostname"       , "mail", "smtp.acme.com"   , prefixArr);
+			writeMailTemplate(bw, cc, "smtp.port"           , "mail", "###"             , prefixArr);
+			writeMailTemplate(bw, cc, "smtp.username"       , "mail", "someUser"        , prefixArr);
+			writeMailTemplate(bw, cc, "smtp.password"       , "mail", "**secret**"      , prefixArr);
+			writeMailTemplate(bw, cc, "ssl.port"            , "mail", "###"             , prefixArr);
+			writeMailTemplate(bw, cc, "ssl.use"             , "mail", "{true|false}"    , prefixArr);
+			writeMailTemplate(bw, cc, "start.tls"           , "mail", "{true|false}"    , prefixArr);
+			writeMailTemplate(bw, cc, "start.tls.required"  , "mail", "{true|false}"    , prefixArr);
+			writeMailTemplate(bw, cc, "smtp.connect.timeout", "mail", "###"             , prefixArr);
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- END: Fallback mail Properties");
+			writeln(bw, "##---------------------------------------------------------");
+
+
+
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- BEGIN: Alarm Handler");
+			writeln(bw, "##---------------------------------------------------------");
+			List<String> alarmKeys    = cc.getKeys("AlarmHandler");
+			List<String> alarmWriters = StringUtil.parseCommaStrToList(cc.getProperty("AlarmHandler.WriterClass", ""), true);
+
+			// Write all keys 'AlarmHandler.*'
+			for (String key : alarmKeys)
+			{
+				writeKey(bw, cc, key);
+			}
+			writeln(bw, "");
+
+			// Writers
+			for (String alarmKey : alarmWriters)
+			{
+				alarmKey = StringUtils.substringAfterLast(alarmKey, ".");
+				writeln(bw, "## Writer: " + alarmKey + " -------------------------");
+				List<String> writerKeys = cc.getKeys(alarmKey);
+				for (String key : writerKeys)
+				{
+					writeKey(bw, cc, key);
+				}
+				writeln(bw, "");
+			}
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- END: Alarm Handler");
+			writeln(bw, "##---------------------------------------------------------");
+			
+			
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- BEGIN: DSR - Daily Summary Report");
+			writeln(bw, "##---------------------------------------------------------");
+			List<String> dsrKeys    = cc.getKeys("DailySummaryReport");
+			List<String> dsrWriters = StringUtil.parseCommaStrToList(cc.getProperty("DailySummaryReport.sender.classname", ""), true);
+
+			// Write all keys 'DailySummaryReport.*'
+			for (String key : dsrKeys)
+			{
+				writeKey(bw, cc, key);
+			}
+			writeln(bw, "");
+
+			// Writers
+			for (String senderKey : dsrWriters)
+			{
+				senderKey = StringUtils.substringAfterLast(senderKey, ".");
+				writeln(bw, "## Sender: " + senderKey + " -------------------------");
+				List<String> senderKeys = cc.getKeys(senderKey);
+				for (String key : senderKeys)
+				{
+					writeKey(bw, cc, key);
+				}
+				writeln(bw, "");
+			}
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- END: DSR - Daily Summary Report");
+			writeln(bw, "##---------------------------------------------------------");
+			
+			
+			//---------------------------------------------------------------------------------
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "");
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- BEGIN: Other stuff not covered in above sections");
+			writeln(bw, "##---------------------------------------------------------");
+			for (String unhandledKey : cc.getKeys())
+			{
+				writeKey(bw, cc, unhandledKey);
+			}
+			writeln(bw, "##---------------------------------------------------------");
+			writeln(bw, "##---- END: Other stuff not covered in above sections");
+			writeln(bw, "##---------------------------------------------------------");
+
+
+			// Finally flush the file
+			os.flush();
+		}
+		catch (IOException ex)
+		{
+			_logger.error("Problems writing to file '" + savetoFile + "'.", ex);
+		}
+		
+		return savetoFile;
+	}
+
+	private void writeMailTemplate(BufferedWriter bw, Configuration conf, String findKey, String mailBase, String keyNotFoundVal, String[] searchPrefixes)
+	throws IOException
+	{
+		// Search all Prefixes
+		String  foundVal = null;
+		for (String searchPrefix : searchPrefixes)
+		{
+			String searchKey = searchPrefix + "." + findKey;
+			if (conf.hasProperty(searchKey))
+			{
+				foundVal = conf.getPropertySuper(searchKey);
+				break;
+			}
+		}
+
+		// Write Found value, or default value if not found
+		String writeKey = mailBase + "." + findKey;
+		if (foundVal != null)
+		{
+			boolean escUnicode = true;
+
+			writeKey = Configuration.saveConvert(writeKey, true, escUnicode);
+
+			/* No need to escape embedded and trailing spaces for value, hence pass false to flag. */
+			foundVal = Configuration.saveConvert(foundVal, false, escUnicode);
+
+			bw.write(StringUtil.left(writeKey, 30, true) + " = " + foundVal);
+			bw.newLine();
+		}
+		else
+		{
+			bw.write(StringUtil.left("#" + writeKey, 30, true) + " = " + keyNotFoundVal);
+			bw.newLine();
+		}
+	}
+
+	private static void writeCmSection(BufferedWriter bw, Configuration conf, String cmName)
+	throws IOException
+	{
+		// Construct a List of all "major" settings for a CM
+		String[] cmOptionsArr = {
+				cmName + ".persistCounters",
+				cmName + ".persistCounters.abs",
+				cmName + ".persistCounters.diff",
+				cmName + ".persistCounters.rate",
+				cmName + ".postponeTime",
+				cmName + ".queryTimeout"
+		};
+		List<String> cmOptions = new ArrayList<>(Arrays.asList(cmOptionsArr));
+		
+		// All Alarms
+		List<String> allAlarmKeysForThisCm = conf.getKeys(cmName + ".alarm.");
+
+		// NOT Common and Alarms
+		List<String> allOtherKeysForThisCm = conf.getKeys(cmName + ".");
+		allOtherKeysForThisCm.removeAll(cmOptions);
+		allOtherKeysForThisCm.removeAll(allAlarmKeysForThisCm);
+
+		String tabGroup = "";
+		String tabName  = "";
+		if (CounterController.hasInstance())
+		{
+			CountersModel cm = CounterController.getInstance().getCmByName(cmName);
+			tabGroup = cm.getGroupName();
+			tabName  = cm.getDisplayName();
+		}
+
+		String printName = cmName;
+		if (StringUtil.hasValue(tabName)) printName += " -- DisplayName='" + tabName + "'";
+		if (StringUtil.hasValue(tabName)) printName += " -- TabGroup='" + tabGroup + "'";
+		writeln(bw, "##-----------------------------------------------------------------------------------------------------------");
+		writeln(bw, "##---- BEGIN: " + printName);
+		writeln(bw, "##-----------------------------------------------------------------------------------------------------------");
+		writeln(bw, "##---- Options ----");
+		for (String key : cmOptions)
+		{
+			writeKey(bw, conf, key);
+		}
+
+		writeln(bw, "##---- Settings ----");
+		for (String key : allOtherKeysForThisCm)
+		{
+			writeKey(bw, conf, key);
+		}
+
+		writeln(bw, "##---- Alarms ----");
+		for (String key : allAlarmKeysForThisCm)
+		{
+			writeKey(bw, conf, key);
+		}
+
+		writeln(bw, "##-----------------------------------------------------------------------------------------------------------");
+		writeln(bw, "##---- END: " + printName);
+		writeln(bw, "##-----------------------------------------------------------------------------------------------------------");
+		writeln(bw, "");
+		writeln(bw, "");
+	}
+	
+	private static void writeln(BufferedWriter bufferedwriter, String s)
+	throws IOException
+	{
+		bufferedwriter.write(s);
+		bufferedwriter.newLine();
+	}
+	private static void writeKey(BufferedWriter bw, Configuration conf, String key)
+	throws IOException
+	{
+		// Get the *REAL* raw values from the prop (as stored in Properties)
+		String val = conf.getPropertySuper(key);
+		if (val == null)
+			val = "";
+
+		// If it looks like a DEFAULT value... Comment it out ;)
+		if (val.startsWith(Configuration.USE_DEFAULT_PREFIX))
+			bw.write("#");
+
+		writeKeyVal(bw, key, val);
+		
+		boolean removeKey = true;
+		if (removeKey)
+		{
+			conf.remove(key);
+		}
+	}
+	private static void writeKeyVal(BufferedWriter bw, String key, String val)
+	throws IOException
+	{
+		boolean escUnicode = true;
+
+		key = Configuration.saveConvert(key, true, escUnicode);
+
+		/* No need to escape embedded and trailing spaces for value, hence pass false to flag. */
+		val = Configuration.saveConvert(val, false, escUnicode);
+
+		bw.write(key + " = " + val);
+		bw.newLine();
+	}
+
+	public static List<String> getCmOsNames() 
+	{
+		Reflections reflections = new Reflections("com.dbxtune.cm.os");
+
+//Set<Class<? extends Object>> allClasses = reflections.getSubTypesOf(Object.class);
+//System.out.println("allClasses: " + allClasses);
+//for (Class<? extends Object> e : allClasses)
+//{
+//	System.out.println("e=" + e.getSimpleName());
+//}
+		// This do NOT seem to work
+		List<String> names = reflections.getSubTypesOf(Object.class).stream()
+			.map(Class::getSimpleName)
+			.filter(name -> name.startsWith("CmOs"))
+			.collect(Collectors.toList());
+
+		// Fallback 
+		if (names.isEmpty())
+		{
+			names.addAll(CmOsUtils.getCmOsNames());
+		}
+		return names;
+	}
+	
+
+	
 	private String getUdcConfigName(String name)
 	{
 		String        udcConfigName  = null;
@@ -445,6 +1004,7 @@ public class WizardOffline
 
 	public static void main(String[] args)
 	{
+//		System.out.println("getCmOsNames(): " + getCmOsNames());
 		try 
 		{
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());

--- a/src/com/dbxtune/gui/wizard/WizardOfflinePage12.java
+++ b/src/com/dbxtune/gui/wizard/WizardOfflinePage12.java
@@ -58,6 +58,7 @@ implements ActionListener
 	private static final String WIZ_HELP = "A filename where this information should be stored to.";
 
 	private JTextField _storeFile = new JTextField("");
+	private JCheckBox  _saveSorted  = new JCheckBox("Save Counter Models as Sorted by the CM Name", false);
 	private JCheckBox  _previewFile = new JCheckBox("Preview the output file when closing the wizard", true);
 
 	public static String getDescription() { return WIZ_DESC; }
@@ -74,6 +75,11 @@ implements ActionListener
 		add( new MultiLineLabel(WIZ_HELP), WizardOffline.MigLayoutHelpConstraints );
 
 		_storeFile.setName("storeFile");
+		
+		_saveSorted.setToolTipText("<html>"
+				+ "TRUE  = Sort by dictionary CmName (from A-Z). <br>"
+				+ "FALSE = Sort by How the CM's was added by " + Version.getAppName() + " (in the GUI Tab Order). <br>"
+				+ "</html>");
 
 		add(new JLabel("Filename"));
 		add(_storeFile, "growx");
@@ -82,6 +88,7 @@ implements ActionListener
 		button.putClientProperty("NAME", "BUTTON_STORE_FILE");
 		add(button, "wrap");
 
+		add(_saveSorted,  "span, wrap");
 		add(_previewFile, "span, wrap");
 
 //		add(new JLabel("Filename 23"));
@@ -119,7 +126,8 @@ implements ActionListener
 		String problem = "";
 		if ( _storeFile.getText().trim().length() <= 0) problem += "Filename, ";
 
-		putWizardData("to-be-discarded.previewFile", _previewFile.isSelected()+"");
+		putWizardData("to-be-discarded.saveSorted" , _saveSorted .isSelected() + "");
+		putWizardData("to-be-discarded.previewFile", _previewFile.isSelected() + "");
 
 		if (problem.length() > 0)
 		{

--- a/src/com/dbxtune/history.html
+++ b/src/com/dbxtune/history.html
@@ -61,6 +61,9 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
         <LI>Changed TemplateLevel() for a bunch of the Counter Models to work with the above 'CounterSet.template.default'</LI>
         <LI>Configuration: can now read content from a file. (key = file: /path/toFile/theFileName)</LI>
         <LI>Finding Changes to Config files WatchService (read changed config files and fire on changed key/value): Fixed/Improved</LI>
+        <LI>Menu -- Tools -- 'Create Record Session - Template file' Wizard...' now writes a template file with comments (and all default values are commented out). You can choose to sort the CM Entries by name or have it in creation order!</LI>
+        <LI>PCS Writers now also Writes "Target Info: <where did we store the data>" in the log file (for tracability)</LI>
+        <LI>AppDir got some improvements for the upcomming Windows: DbxInstaller</LI>
 
 		<LI><b>Alarms Handling:</b>
 			<UL>
@@ -196,6 +199,7 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
         <li>Admin Page: Add Collector: Refresh/Restart buttons</li>
         <li>Admin Page: Improve user table in admin UI (Last Login, Login Count, Login Fail Count columns)</li>
         <li>Tried to fix "missing Counder Data"... If the PCS is slow at storing data... we might "not see it" at DbxCentral -- So Basically retry fetch data (BUT I could NOT test this, so it might still be broken)</li>
+        <li>Counter Details -- Remember current tab name within a "tab group" (move more fluently between tabs, and remember the last visited CM)</li>
 	</UL>
 	<!-- ~~~end-of-this-tool~~~ -->
 
@@ -360,7 +364,9 @@ or at: <A HREF="http://sourceforge.net/projects/asetune/files/">http://sourcefor
 			<li><b>SqlServerTopCmExecQueryStatPerDb</b> -- added column 'total_waisted_grant_kb__sum' & 'AvgWaistedGrantKb'</li>
 			<li><b>SqlServerTopCmExecQueryStat     </b> -- added column 'total_waisted_grant_kb__sum' & 'AvgWaistedGrantKb'</li>
 			<li><b>SqlServerTopCmExecQueryStatDb   </b> -- added column 'total_waisted_grant_kb__sum' & 'AvgWaistedGrantKb'</li>
-			<li><b>Query Store                     </b> -- Fixed some calculation bug (previously it calculated to high values from Elapsed and CPU Time etc...)</b>
+			<li><b>Query Store                     </b> -- Fixed some calculation bug (previously it calculated to high values from Elapsed and CPU Time etc...)</li>
+			<li><b>SqlServerJobScheduler           </b> -- Added column 'scheduledLast24hChart', which is a "gantt" that tries to visualize when a job was executed during the day.</li>
+			
 		</ul>
 		</LI>
 	</UL>

--- a/src/com/dbxtune/pcs/IPersistWriter.java
+++ b/src/com/dbxtune/pcs/IPersistWriter.java
@@ -220,5 +220,13 @@ public interface IPersistWriter
 //	public int getSqlCaptureBatchCount();
 
 	public PersistWriterStatistics getStatistics();
+
+	/** 
+	 * Get a info String about the Target storage for this writer
+	 * <p>
+	 * This will be used when printing: Persisting Counters using 'PersistWriterXxx'... h2WriterStat... writerStatistics... targetInfo...
+	 */
+	public String getTargetInfo(); 
+
 	public void resetCounters();
 }

--- a/src/com/dbxtune/pcs/PersistWriterJdbc.java
+++ b/src/com/dbxtune/pcs/PersistWriterJdbc.java
@@ -1152,6 +1152,17 @@ public class PersistWriterJdbc
 	}
 
 	@Override
+	public String getTargetInfo()
+	{
+		String info = "";
+
+		info = "JdbcUrl='" + _lastUsedUrl + "'";
+		
+		return info;
+	}
+
+
+	@Override
 	public void init(Configuration props) throws Exception
 	{
 		_config = props;

--- a/src/com/dbxtune/pcs/PersistWriterToBcpFiles.java
+++ b/src/com/dbxtune/pcs/PersistWriterToBcpFiles.java
@@ -131,6 +131,12 @@ public class PersistWriterToBcpFiles
 	}
 
 	@Override
+	public String getTargetInfo()
+	{
+		return "toDir='" + _saveToDir + "'";
+	}
+
+	@Override
 	public void init(Configuration props) throws Exception
 	{
 		_config = props;

--- a/src/com/dbxtune/pcs/PersistWriterToDbxCentral.java
+++ b/src/com/dbxtune/pcs/PersistWriterToDbxCentral.java
@@ -179,6 +179,27 @@ extends PersistWriterToHttpJson
 	}
 
 	@Override
+	public String getTargetInfo()
+	{
+		String info = "";
+
+		if (_httpConfSlot != null)
+		{
+			info = "ToUrl='" + _httpConfSlot._url + "'";
+		}
+
+		if (_fileConfSlot != null)
+		{
+			if (StringUtil.hasValue(info))
+				info += ", ";
+
+			info += "ToDir='" + _fileConfSlot._dirName + "'";
+		}
+		
+		return info;
+	}
+
+	@Override
 	public void init(Configuration conf) throws Exception
 	{
 //System.out.println(getName() + ": INIT.....................................");

--- a/src/com/dbxtune/pcs/PersistWriterToHttpJson.java
+++ b/src/com/dbxtune/pcs/PersistWriterToHttpJson.java
@@ -80,6 +80,7 @@ extends PersistWriterBase
 
 		return _writerStatistics;
 	}
+	
 
 	@Override
 	public void resetCounters()
@@ -419,6 +420,26 @@ extends PersistWriterBase
 			printConfig(slot);
 		}
 	}
+
+	
+	@Override
+	public String getTargetInfo()
+	{
+		String info = "";
+
+		info = _confSlot0._cfgName + "[ToUrl='" + _confSlot0._url + "']";
+		
+		for (HttpConfigSlot slot : _confSlots)
+		{
+			if (StringUtil.hasValue(info))
+				info += ", ";
+
+			info = slot._cfgName + "[ToUrl='" + slot._url + "']";
+		}
+
+		return info;
+	}
+
 
 	private void checkOrCreateRecoveryDir(HttpConfigSlot httpConfigSlot)
 	{

--- a/src/com/dbxtune/pcs/PersistWriterToInfluxDb.java
+++ b/src/com/dbxtune/pcs/PersistWriterToInfluxDb.java
@@ -802,6 +802,25 @@ extends PersistWriterBase
 	}
 
 	@Override
+	public String getTargetInfo()
+	{
+		String info = "";
+
+		info = _confSlot0._cfgName + "[ToUrl='" + _confSlot0._url + "']";
+		
+		for (ConfigSlot slot : _confSlots)
+		{
+			if (StringUtil.hasValue(info))
+				info += ", ";
+
+			info = slot._cfgName + "[ToUrl='" + slot._url + "']";
+		}
+
+		return info;
+	}
+
+
+	@Override
 	public void init(Configuration conf) throws Exception
 	{
 		System.out.println(getName()+": INIT.....................................");

--- a/src/com/dbxtune/pcs/PersistentCounterHandler.java
+++ b/src/com/dbxtune/pcs/PersistentCounterHandler.java
@@ -1252,7 +1252,7 @@ implements Runnable
 //				}
 				
 				// Fire changes
-				firePcsConsumeInfo(pw.getName(), cont.getServerNameOrAlias(), cont.getSessionStartTime(), cont.getMainSampleTime(), (int)execTime, pw.getStatistics());
+				firePcsConsumeInfo(pw.getName(), cont.getServerNameOrAlias(), cont.getSessionStartTime(), cont.getMainSampleTime(), (int)execTime, pw.getStatistics(), pw.getTargetInfo());
 
 				// Reset the statistics
 				pw.resetCounters();
@@ -1995,7 +1995,7 @@ implements Runnable
 		 * @param persistTimeInMs     Number of milliseconds it took for the Performance Writer to store the data
 		 * @param writerStatistics    The actual statistical counters object
 		 */
-		public void pcsConsumeInfo(String persistWriterName, Timestamp sessionStartTime, Timestamp mainSampleTime, int persistTimeInMs, PersistWriterStatistics writerStatistics);
+		public void pcsConsumeInfo(String persistWriterName, Timestamp sessionStartTime, Timestamp mainSampleTime, int persistTimeInMs, PersistWriterStatistics writerStatistics, String targetInfo);
 	}
 
 	/** listeners */
@@ -2034,7 +2034,7 @@ implements Runnable
 
 	/** Kicked off when consume is done
 	 * @param ddlSaveCount */
-	public void firePcsConsumeInfo(String persistWriterName, String serverName, Timestamp sessionStartTime, Timestamp mainSampleTime, int persistTimeInMs, PersistWriterStatistics writerStatistics)
+	public void firePcsConsumeInfo(String persistWriterName, String serverName, Timestamp sessionStartTime, Timestamp mainSampleTime, int persistTimeInMs, PersistWriterStatistics writerStatistics, String targetInfo)
 	{
 		if (mainSampleTime != null)
 			_lastPersistedSampleTimeMs = Math.max(_lastPersistedSampleTimeMs, mainSampleTime.getTime());
@@ -2047,6 +2047,8 @@ implements Runnable
 		_maxLenPersistWriterName = Math.max(_maxLenPersistWriterName, persistWriterName.length());
 		_maxLenServerName        = Math.max(_maxLenServerName,        serverName       .length());
 
+		targetInfo = (targetInfo == null) ? "" : ". TargetInfo: " + targetInfo;
+		
 		_logger.info("Persisting Counters using " + StringUtil.left("'" + persistWriterName + "', ", _maxLenPersistWriterName+4)
 				+ "for serverName="               + StringUtil.left("'" + serverName        + "', ", _maxLenServerName+4)
 				+ "sessionStartTime='"            + StringUtil.left(sessionStartTime + "",23)     + "', "
@@ -2055,10 +2057,11 @@ implements Runnable
 				+ "qs="                           + StringUtil.left(pcsQueueSize + ".", 4) // ###.
 				+ "jvmMemoryLeftInMB="            + Memory.getMemoryLeftInMB() + ". " 
 				+ h2WriterStat 
-				+ writerStatistics.getStatisticsString() );
+				+ writerStatistics.getStatisticsString()
+				+ targetInfo );
 
 		for (PcsQueueChange l : _queueChangeListeners)
-			l.pcsConsumeInfo(persistWriterName, sessionStartTime, mainSampleTime, persistTimeInMs, writerStatistics);
+			l.pcsConsumeInfo(persistWriterName, sessionStartTime, mainSampleTime, persistTimeInMs, writerStatistics, targetInfo);
 	}
 	// Below are just used for formating the above string (for readability)
 	private int _maxLenPersistWriterName = 0;

--- a/src/com/dbxtune/pcs/report/content/SparklineJfreeChart.java
+++ b/src/com/dbxtune/pcs/report/content/SparklineJfreeChart.java
@@ -47,11 +47,16 @@ import org.jfree.chart.axis.ValueAxis;
 import org.jfree.chart.event.AnnotationChangeListener;
 import org.jfree.chart.plot.PlotRenderingInfo;
 import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.StandardXYBarPainter;
 import org.jfree.chart.renderer.xy.StandardXYItemRenderer;
+import org.jfree.chart.renderer.xy.XYBarRenderer;
 import org.jfree.chart.ui.ApplicationFrame;
 import org.jfree.chart.ui.RectangleInsets;
 import org.jfree.data.Range;
 import org.jfree.data.time.Minute;
+import org.jfree.data.time.SimpleTimePeriod;
+import org.jfree.data.time.TimePeriodValues;
+import org.jfree.data.time.TimePeriodValuesCollection;
 import org.jfree.data.time.TimeSeries;
 import org.jfree.data.time.TimeSeriesCollection;
 import org.jfree.ui.RefineryUtilities;
@@ -97,6 +102,89 @@ public class SparklineJfreeChart
 	 * @param indicatorDecimalPoints      Number of decimal points for the Indicator value (-1 = Do not show the Indicator Text) 
 	 * @return
 	 */
+	private SparklineJfreeChart() {}
+
+	/**
+	 * Create a 24h bar/block chart spanning a fixed time range (typically midnight→midnight).<br>
+	 * Each execution is rendered as a filled horizontal block: x-start = ts, x-end = ts + duration.
+	 * <p>
+	 * Unlike the regular sparkline, the x-axis is <b>fixed</b> so that bar positions reflect
+	 * actual time-of-day regardless of how many executions are present.
+	 *
+	 * @param data          Sparkline data (beginTs = start of execution, values = duration in seconds)
+	 * @param dayStart      Start of the fixed x-axis range (typically 00:00:00 of the day)
+	 * @param dayEnd        End   of the fixed x-axis range (typically 00:00:00 of the next day)
+	 * @param bucketMinutes Bucket size in minutes — used as minimum bar width so even instant jobs are visible
+	 * @param numBuckets    Total number of buckets — used as the PNG image width (1 px per bucket)
+	 * @return Inline HTML {@code <img>} tag with a base64-encoded PNG
+	 */
+	public static String create24hGanttChart(SparklineResult data, Timestamp dayStart, Timestamp dayEnd, int bucketMinutes, int numBuckets)
+	{
+		long minBarWidthMs = bucketMinutes * 60_000L;
+
+		TimePeriodValues series = new TimePeriodValues("Executions");
+		for (int i = 0; i < data.beginTs.size(); i++)
+		{
+			Timestamp begin = data.beginTs.get(i);
+			Number    sec   = data.values.get(i);
+
+			long beginMs    = begin.getTime();
+			long durationMs = (sec == null ? 0 : sec.longValue() * 1000L);
+			long endMs      = beginMs + Math.max(durationMs, minBarWidthMs);
+
+			// Clamp to day boundary
+			endMs = Math.min(endMs, dayEnd.getTime());
+
+			series.add(new SimpleTimePeriod(beginMs, endMs), 1.0);
+		}
+
+		TimePeriodValuesCollection dataset = new TimePeriodValuesCollection(series);
+
+		Color transparent = new Color(0, 0, 0, 0);
+		Color barColor    = new Color(70, 130, 180); // SteelBlue
+
+		DateAxis x = new DateAxis();
+		x.setRange(new java.util.Date(dayStart.getTime()), new java.util.Date(dayEnd.getTime()));
+		x.setTickLabelsVisible(false);
+		x.setTickMarksVisible(false);
+		x.setAxisLineVisible(false);
+		x.setNegativeArrowVisible(false);
+		x.setPositiveArrowVisible(false);
+		x.setVisible(false);
+
+		NumberAxis y = new NumberAxis();
+		y.setRange(new Range(0, 1.2));
+		y.setTickLabelsVisible(false);
+		y.setTickMarksVisible(false);
+		y.setAxisLineVisible(false);
+		y.setNegativeArrowVisible(false);
+		y.setPositiveArrowVisible(false);
+		y.setVisible(false);
+
+		XYBarRenderer renderer = new XYBarRenderer(0.1);
+		renderer.setBarPainter(new StandardXYBarPainter()); // solid fill, no gradient
+		renderer.setShadowVisible(false);
+		renderer.setDrawBarOutline(false);
+		renderer.setSeriesPaint(0, barColor);
+
+		XYPlot plot = new XYPlot(dataset, x, y, renderer);
+		plot.setInsets(new RectangleInsets(-1, -1, 1, 0));
+		plot.setDomainGridlinesVisible(false);
+		plot.setDomainCrosshairVisible(false);
+		plot.setRangeGridlinesVisible(false);
+		plot.setRangeCrosshairVisible(false);
+		plot.setBackgroundPaint(transparent);
+
+		JFreeChart chart = new JFreeChart(null, JFreeChart.DEFAULT_TITLE_FONT, plot, false);
+		chart.setBorderVisible(false);
+		chart.setBackgroundPaint(transparent);
+
+		SparklineJfreeChart wrapper = new SparklineJfreeChart();
+		wrapper._chart = chart;
+		return wrapper.toHtmlInlineImage(numBuckets, 19);
+	}
+
+
 	public SparklineJfreeChart(SparklineResult data, SparklineResultType type, int indicatorDecimalPoints)
 	{
 		_indicatorDecimalPoints = indicatorDecimalPoints;

--- a/src/com/dbxtune/pcs/report/content/sqlserver/SqlServerJobScheduler.java
+++ b/src/com/dbxtune/pcs/report/content/sqlserver/SqlServerJobScheduler.java
@@ -71,6 +71,9 @@ extends SqlServerAbstract
 	public static final String PROPKEY_errors_skip_below_severity = "DailySummaryReport.SqlServerJobScheduler.skip.severity.below";
 	public static final int    DEFAULT_errors_skip_below_severity = 10; // 
 	
+	public static final String PROPKEY_JobSchedulerTimelineBucketSizeInMinutes = "DailySummaryReport.SqlServerJobScheduler.timeline.gantt.bucket.size.in.minutes";
+	public static final int    DEFAULT_JobSchedulerTimelineBucketSizeInMinutes = 5; // 
+	
 	private List<String>        _miniChartJsList = new ArrayList<>();
 	
 	private boolean _pcsSchemaOrTableWasNotFound = false;
@@ -570,6 +573,7 @@ extends SqlServerAbstract
 			    + "    ,'' AS [stepCmds] \n"
 			    + "    ,[runStatusDesc] \n"
 			    + "    ,[execCount] \n"
+			    + "    ,'' AS [scheduledLast24hChart] \n" // Fill this one with a chart of "histAllExecTimes" for the the full day (just the last full day)
 			    + "    ,[sumTimeInSec] \n"
 			    + "    ,[sumTime_HMS] \n"
 			    + "    ,[avgTimeInSec] \n"
@@ -626,6 +630,7 @@ extends SqlServerAbstract
 //			String histAllExecTimes = _job_history_overview.getValueAsString(r, "histAllExecTimes");
 			String histAllExecTimes = getTooltipFor_allExecTimes(job_id, step_id);
 			createSparklineForHistoryExecutions(histAllExecTimes, _job_history_overview, r, "histAllExecTimesChart");
+			createSparklineForLast24hScheduled (histAllExecTimes, _job_history_overview, r, "scheduledLast24hChart");
 			
 			// calculate the 'avgHistTimeDiff' column
 			int avgTimeInSec     = _job_history_overview.getValueAsInteger(r, "avgTimeInSec");
@@ -641,37 +646,38 @@ extends SqlServerAbstract
 			_job_history_overview.setValueAtWithOverride(avgHistTimeDiffStr, r, pos_avgHistTimeDiff);
 		}
 		
-		_job_history_overview.setColumnDescription("JobName"           ,"Name of the JOB shat started this step");
-		_job_history_overview.setColumnDescription("timeline"          ,"Click on the below for a TimeLine on 'today' or 'all executions'");
-		_job_history_overview.setColumnDescription("histGraph"         ,"A tooltip/popup with timings of ALL jobs in the last ## days, click to see Graph on the exec times");
-		_job_history_overview.setColumnDescription("execView"          ,"Open DbxTune/DbxCentral in historical mode and position to the start time of the job/step");
-		_job_history_overview.setColumnDescription("stepCount"         ,"How many steps does this job name have");
-		_job_history_overview.setColumnDescription("stepCmds"          ,"A list of all commands in the job");
-		_job_history_overview.setColumnDescription("runStatusDesc"     ,"The outcome of the job. Can be: FAILED, SUCCESS, RETRY, CANCELED or IN PROGRESS");
-		_job_history_overview.setColumnDescription("execCount"         ,"How many times has this JOB been executed in the reporting period");
-		_job_history_overview.setColumnDescription("sumTimeInSec"      ,"Summary Execution time in Seconds for all Executions in reporting period");
-		_job_history_overview.setColumnDescription("sumTime_HMS"       ,"Summary Execution time in Hour:Minute:Seconds for all Executions in reporting period");
-		_job_history_overview.setColumnDescription("avgTimeInSec"      ,"Average Execution time in Seconds for all Executions in reporting period");
-		_job_history_overview.setColumnDescription("avgTime_HMS"       ,"Average Execution time in Hour:Minute:Seconds for all Executions in reporting period");
-		_job_history_overview.setColumnDescription("avgHistTimeDiff"   ,"The difference of 'avgTime_HMS' and 'histAvgTime_HMS' this could be a positive (Slower) or negative (faster) than the average history.");
-		_job_history_overview.setColumnDescription("minTime_HMS"       ,"Minimum Execution time in Hour:Minute:Seconds for all Executions in reporting period");
-		_job_history_overview.setColumnDescription("maxTime_HMS"       ,"Maximum Execution time in Hour:Minute:Seconds for all Executions in reporting period");
-		_job_history_overview.setColumnDescription("stdevp"            ,"Standard Deviation Number of the Execution Time. Note: A higher number means more 'outliers', A lower number means more 'equal' execution times.");
-		_job_history_overview.setColumnDescription("firstExecTime"     ,"Time when this job was FIRST executed in in reporting period");
-		_job_history_overview.setColumnDescription("lastExecTime"      ,"Time when this job was LAST executed in in reporting period");
+		_job_history_overview.setColumnDescription("JobName"               ,"Name of the JOB shat started this step");
+		_job_history_overview.setColumnDescription("timeline"              ,"Click on the below for a TimeLine on 'today' or 'all executions'");
+		_job_history_overview.setColumnDescription("histGraph"             ,"A tooltip/popup with timings of ALL jobs in the last ## days, click to see Graph on the exec times");
+		_job_history_overview.setColumnDescription("execView"              ,"Open DbxTune/DbxCentral in historical mode and position to the start time of the job/step");
+		_job_history_overview.setColumnDescription("stepCount"             ,"How many steps does this job name have");
+		_job_history_overview.setColumnDescription("stepCmds"              ,"A list of all commands in the job");
+		_job_history_overview.setColumnDescription("runStatusDesc"         ,"The outcome of the job. Can be: FAILED, SUCCESS, RETRY, CANCELED or IN PROGRESS");
+		_job_history_overview.setColumnDescription("execCount"             ,"How many times has this JOB been executed in the reporting period");
+		_job_history_overview.setColumnDescription("scheduledLast24hChart" ,"When was this job scheduled in the last day. \nThis will be presented as a \"mini Gantt chart\" Visualizing when a job was executed during the day. \n\nNumber if minutes for each 'bucket' is by default " + DEFAULT_JobSchedulerTimelineBucketSizeInMinutes + " minutes. \nThis can be changed with property '" + PROPKEY_JobSchedulerTimelineBucketSizeInMinutes + " = ##'. \nNote: A shorter timespan will make the chart *wider*, for example 1 would be optimal... but then the chart will occupy a lot of space.\n\n\nIf you want to view a Chart with Execution Times: Click on Cell 'Show' at column 'histGraph' where the avilable history will be visible.");
+		_job_history_overview.setColumnDescription("sumTimeInSec"          ,"Summary Execution time in Seconds for all Executions in reporting period");
+		_job_history_overview.setColumnDescription("sumTime_HMS"           ,"Summary Execution time in Hour:Minute:Seconds for all Executions in reporting period");
+		_job_history_overview.setColumnDescription("avgTimeInSec"          ,"Average Execution time in Seconds for all Executions in reporting period");
+		_job_history_overview.setColumnDescription("avgTime_HMS"           ,"Average Execution time in Hour:Minute:Seconds for all Executions in reporting period");
+		_job_history_overview.setColumnDescription("avgHistTimeDiff"       ,"The difference of 'avgTime_HMS' and 'histAvgTime_HMS' this could be a positive (Slower) or negative (faster) than the average history.");
+		_job_history_overview.setColumnDescription("minTime_HMS"           ,"Minimum Execution time in Hour:Minute:Seconds for all Executions in reporting period");
+		_job_history_overview.setColumnDescription("maxTime_HMS"           ,"Maximum Execution time in Hour:Minute:Seconds for all Executions in reporting period");
+		_job_history_overview.setColumnDescription("stdevp"                ,"Standard Deviation Number of the Execution Time. Note: A higher number means more 'outliers', A lower number means more 'equal' execution times.");
+		_job_history_overview.setColumnDescription("firstExecTime"         ,"Time when this job was FIRST executed in in reporting period");
+		_job_history_overview.setColumnDescription("lastExecTime"          ,"Time when this job was LAST executed in in reporting period");
 
-		_job_history_overview.setColumnDescription("histExecCount"     ,"How many times was the job executed in the last ## days");
-		_job_history_overview.setColumnDescription("histDaysCount"     ,"How many days is included in the history");
-		_job_history_overview.setColumnDescription("histFirstExecTime" ,"First execution time  in the last ## days");
-		_job_history_overview.setColumnDescription("histAvgTimeInSec"  ,"Average number of seconds this job took for the last ## days");
-		_job_history_overview.setColumnDescription("histAvgTime_HMS"   ,"Average Hour:Minute:Seconds this job took for the last ## days");
-		_job_history_overview.setColumnDescription("histMinTime_HMS"   ,"Minimum Hour:Minute:Seconds this job took for the last ## days");
-		_job_history_overview.setColumnDescription("histMaxTime_HMS"   ,"Max Hour:Minute:Seconds this job took for the last ## days");
-		_job_history_overview.setColumnDescription("histStdevp"        ,"Standard Deviation Number of the Execution Time for the last ## days. Note: A higher number means more 'outliers', A lower number means more 'equal' execution times.");
-		_job_history_overview.setColumnDescription("histAllExecTimes"  ,"A tooltip/popup with timings of ALL jobs in the last ## days, click to see Graph on the exec times");
-		_job_history_overview.setColumnDescription("histAllExecTimesChart"  ,"A Chart with the timings of ALL jobs in the last ## days");
+		_job_history_overview.setColumnDescription("histExecCount"         ,"How many times was the job executed in the last ## days");
+		_job_history_overview.setColumnDescription("histDaysCount"         ,"How many days is included in the history");
+		_job_history_overview.setColumnDescription("histFirstExecTime"     ,"First execution time  in the last ## days");
+		_job_history_overview.setColumnDescription("histAvgTimeInSec"      ,"Average number of seconds this job took for the last ## days");
+		_job_history_overview.setColumnDescription("histAvgTime_HMS"       ,"Average Hour:Minute:Seconds this job took for the last ## days");
+		_job_history_overview.setColumnDescription("histMinTime_HMS"       ,"Minimum Hour:Minute:Seconds this job took for the last ## days");
+		_job_history_overview.setColumnDescription("histMaxTime_HMS"       ,"Max Hour:Minute:Seconds this job took for the last ## days");
+		_job_history_overview.setColumnDescription("histStdevp"            ,"Standard Deviation Number of the Execution Time for the last ## days. Note: A higher number means more 'outliers', A lower number means more 'equal' execution times.");
+		_job_history_overview.setColumnDescription("histAllExecTimes"      ,"A tooltip/popup with timings of ALL jobs in the last ## days, click to see Graph on the exec times");
+		_job_history_overview.setColumnDescription("histAllExecTimesChart" ,"A Chart with the timings of ALL jobs in the last ## days");
 
-		_job_history_overview.setColumnDescription("job_id"            ,"The ID of the JOB");
+		_job_history_overview.setColumnDescription("job_id"                ,"The ID of the JOB");
 
 		// Get All JobStep Commands for a 'job_id', and put it in a Map, used later to compose a ToolTip
 		getJobStepCommandsTooltipForJobId(conn, _job_history_overview, "job_id");
@@ -1217,6 +1223,249 @@ extends SqlServerAbstract
 	 * </code>
 	 * 
 	 */
+	/**
+	 * Build a 24h "schedule activity" chart for the LAST calendar day found in {@code textToParse}.
+	 * <p>
+	 * The chart has two layers (same pattern as {@link #createSparklineForHistoryExecutions}):
+	 * <ol>
+	 *   <li><b>JFreeChart PNG</b> — fixed 00:00–23:59 x-axis with filled bars (start→end of each execution).
+	 *       Shown in email clients and anywhere JavaScript is unavailable.</li>
+	 *   <li><b>jQuery sparkline</b> (<code>type:'bar'</code>) — replaces the PNG in a browser.
+	 *       The 24h period is divided into {@value #SCHEDULED_24H_BUCKET_MINUTES}-minute buckets (
+	 *       {@value #SCHEDULED_24H_NUM_BUCKETS} values total).
+	 *       Each bucket value = number of executions that were <i>active</i> during that bucket,
+	 *       so overlapping or back-to-back jobs produce taller bars.</li>
+	 * </ol>
+	 */
+//	private static final int SCHEDULED_24H_BUCKET_MINUTES = 5;
+	private static final int SCHEDULED_24H_BUCKET_MINUTES = Configuration.getCombinedConfiguration().getIntProperty(PROPKEY_JobSchedulerTimelineBucketSizeInMinutes, DEFAULT_JobSchedulerTimelineBucketSizeInMinutes);
+	private static final int SCHEDULED_24H_NUM_BUCKETS    = (24 * 60) / SCHEDULED_24H_BUCKET_MINUTES; // 288 for a 5 minute bucket size
+
+	private void createSparklineForLast24hScheduled(String textToParse, ResultSetTableModel rstm, int row, String colName)
+	{
+		List<String> allLines = Arrays.asList(StringUtils.split(textToParse, "\n"));
+
+		if (allLines.isEmpty())
+			return;
+
+		// Find the latest calendar date in the data (e.g. "2024-11-15")
+		String lastDate = null;
+		for (String line : allLines)
+		{
+			if ( ! line.startsWith("ts=") )
+				continue;
+			String tsStr = StringUtil.substringBetweenTwoChars(line, "ts=", ",").trim();
+			if (tsStr.length() >= 10)
+			{
+				String dateOnly = tsStr.substring(0, 10);
+				if (lastDate == null || dateOnly.compareTo(lastDate) > 0)
+					lastDate = dateOnly;
+			}
+		}
+
+		if (lastDate == null)
+			return;
+
+		// Filter to only lines from that last date
+		final String filterDate = lastDate;
+		List<String> lines = new ArrayList<>();
+		for (String line : allLines)
+		{
+			if ( ! line.startsWith("ts=") )
+				continue;
+			String tsStr = StringUtil.substringBetweenTwoChars(line, "ts=", ",").trim();
+			if (tsStr.startsWith(filterDate))
+				lines.add(line);
+		}
+
+		int pos_chartColumnName = rstm.findColumnMandatory(colName);
+		if (pos_chartColumnName == -1)
+			return;
+
+		//--------------------------------------------------------------------
+		// Build SparklineResult — used by JFreeChart PNG and getIndicatorValueLabel()
+		//--------------------------------------------------------------------
+		SparklineResult result = new SparklineResult(SparklineResultType.MAX);
+		for (String line : lines)
+		{
+			String tsStr     = StringUtil.substringBetweenTwoChars(line, "ts=",     ",").trim();
+			String wdStr     = StringUtil.substringBetweenTwoChars(line, "wd=",     ",").trim();
+			String hmsStr    = StringUtil.substringBetweenTwoChars(line, "HMS=",    ",").trim();
+			String secStr    = StringUtil.substringBetweenTwoChars(line, "sec=",    ",").trim();
+			String statusStr = StringUtil.substringBetweenTwoChars(line, "status=", ";").trim();
+			try
+			{
+				Timestamp ts  = TimeUtils.parseToTimestamp(tsStr, "yyyy-MM-dd HH:mm:ss");
+				int       sec = StringUtil.parseInt(secStr, -1);
+				String tooltip = "<br>" + tsStr + " (" + wdStr + ")<br>" + hmsStr + " (" + secStr + " Seconds)<br><br>Status: " + statusStr + "<br>";
+				result.beginTs .add(ts);
+				result.values  .add(sec);
+				result.tooltips.add(tooltip);
+			}
+			catch (Exception e)
+			{
+				_logger.warn("Skipping entry in createSparklineForLast24hScheduled(rstm.name='" + rstm.getName() + "', row=" + row + "') ... Caught: " + e);
+			}
+		}
+
+		if (result.values.isEmpty())
+			return;
+
+		//--------------------------------------------------------------------
+		// Compute fixed x-axis range: midnight → midnight of the last day
+		//--------------------------------------------------------------------
+		Timestamp dayStart;
+		try
+		{
+			dayStart = TimeUtils.parseToTimestamp(filterDate + " 00:00:00", "yyyy-MM-dd HH:mm:ss");
+		}
+		catch (Exception e)
+		{
+			_logger.warn("createSparklineForLast24hScheduled(): Could not parse day start for filterDate='" + filterDate + "'. Skipping. Caught: " + e);
+			return;
+		}
+		Timestamp dayEnd = new Timestamp(dayStart.getTime() + 24L * 60 * 60 * 1000);
+
+		//--------------------------------------------------------------------
+		// Build 5-minute bucket array for jQuery sparkline.
+		// Iterate over BUCKETS (not minutes) so each execution contributes exactly
+		// 1 to each bucket it overlaps — not 1 per minute within that bucket.
+		//--------------------------------------------------------------------
+		int[]              buckets          = new int    [SCHEDULED_24H_NUM_BUCKETS];
+		boolean[]          bucketHasFailure = new boolean[SCHEDULED_24H_NUM_BUCKETS];
+		List<List<String>> bucketExecLines  = new ArrayList<>(SCHEDULED_24H_NUM_BUCKETS);
+		for (int b = 0; b < SCHEDULED_24H_NUM_BUCKETS; b++)
+			bucketExecLines.add(new ArrayList<>());
+
+		for (String line : lines)
+		{
+			String tsStr     = StringUtil.substringBetweenTwoChars(line, "ts=",     ",").trim();
+			String secStr    = StringUtil.substringBetweenTwoChars(line, "sec=",    ",").trim();
+			String hmsStr    = StringUtil.substringBetweenTwoChars(line, "HMS=",    ",").trim();
+			String statusStr = StringUtil.substringBetweenTwoChars(line, "status=", ";").trim();
+			try
+			{
+				Timestamp ts           = TimeUtils.parseToTimestamp(tsStr, "yyyy-MM-dd HH:mm:ss");
+				int       sec          = StringUtil.parseInt(secStr, 0);
+				boolean   isFailure    = ! "SUCCESS".equals(statusStr);
+				int       startMin     = ts.toLocalDateTime().getHour() * 60 + ts.toLocalDateTime().getMinute();
+				int       durationMins = Math.max(1, (int) Math.ceil(sec / 60.0));
+
+				// Compute display start/end times
+				int    endMin      = Math.min(startMin + durationMins, 24 * 60 - 1);
+				String startHHMM   = String.format("%02d:%02d", startMin / 60, startMin % 60);
+				String endHHMM     = String.format("%02d:%02d", endMin   / 60, endMin   % 60);
+				String colorStyle  = isFailure ? " style=\\'color:red;\\'" : "";
+				String execLine    = "<span" + colorStyle + ">&#8226; " + startHHMM + " &#8594; " + endHHMM + " (" + hmsStr + ") " + statusStr + "</span>";
+
+				// Fill each bucket this execution overlaps — exactly once per bucket
+				int startBucket = startMin / SCHEDULED_24H_BUCKET_MINUTES;
+				int endBucket   = Math.min((startMin + durationMins - 1) / SCHEDULED_24H_BUCKET_MINUTES, SCHEDULED_24H_NUM_BUCKETS - 1);
+				for (int b = startBucket; b <= endBucket; b++)
+				{
+					buckets[b]++;
+					if (isFailure)
+						bucketHasFailure[b] = true;
+					bucketExecLines.get(b).add(execLine);
+				}
+			}
+			catch (Exception e)
+			{
+				_logger.warn("Skipping bucket-fill entry in createSparklineForLast24hScheduled() ... Caught: " + e);
+			}
+		}
+
+		//--------------------------------------------------------------------
+		// JFreeChart PNG — email/no-JS fallback (fixed 24h bar blocks)
+		//--------------------------------------------------------------------
+		String jfreeChartInlinePng = SparklineJfreeChart.create24hGanttChart(result, dayStart, dayEnd, SCHEDULED_24H_BUCKET_MINUTES, SCHEDULED_24H_NUM_BUCKETS);
+
+		//--------------------------------------------------------------------
+		// Build sparkline div WITH values= so jQuery sparkline activates in browser
+		//--------------------------------------------------------------------
+		StringBuilder sbVals = new StringBuilder();
+		for (int i = 0; i < SCHEDULED_24H_NUM_BUCKETS; i++)
+		{
+			if (i > 0) sbVals.append(",");
+			sbVals.append(buckets[i]);
+		}
+
+		String sparklineClassName = "sparklines_" + rstm.getName() + "__24h_chart_row_" + row;
+
+		String sparklineDiv = "<div class='sparkline-wrapper'>"
+				+ "<div class='" + sparklineClassName + "' values='" + sbVals + "'>" + jfreeChartInlinePng + "</div>"
+				+ "</div>";
+
+		rstm.setValueAtWithOverride(sparklineDiv, row, pos_chartColumnName);
+
+		//--------------------------------------------------------------------
+		// jQuery sparkline init code — type:'bar', per-bucket tooltips
+		// First ensure the shared infrastructure block is written (once per report)
+		//--------------------------------------------------------------------
+		_miniChartJsList.add(SparklineHelper.getJavaScriptInitCode(this, null, "", ""));
+
+		// colorMap: red for failure buckets, SteelBlue otherwise
+		StringBuilder sbColorMap = new StringBuilder("[");
+		for (int b = 0; b < SCHEDULED_24H_NUM_BUCKETS; b++)
+		{
+			if (b > 0) sbColorMap.append(",");
+			sbColorMap.append(bucketHasFailure[b] ? "'#FF4444'" : "'#4682B4'");
+		}
+		sbColorMap.append("]");
+
+		// Per-bucket tooltip array — empty string for 0-execution buckets (tooltipFormatter suppresses those)
+		String jsVarName = sparklineClassName.replaceAll("[^a-zA-Z0-9]", "_") + "_tips";
+		StringBuilder sbTips = new StringBuilder("var " + jsVarName + " = [\n");
+		for (int b = 0; b < SCHEDULED_24H_NUM_BUCKETS; b++)
+		{
+			if (b > 0) sbTips.append(",\n");
+			List<String> execLines = bucketExecLines.get(b);
+			if (execLines.isEmpty())
+			{
+				sbTips.append("    ''");
+			}
+			else
+			{
+				int    bStart    = b * SCHEDULED_24H_BUCKET_MINUTES;
+				int    bEnd      = bStart + SCHEDULED_24H_BUCKET_MINUTES;
+				String timeRange = String.format("<b>%02d:%02d&#8211;%02d:%02d</b>", bStart / 60, bStart % 60, bEnd / 60, bEnd % 60);
+				StringBuilder tip = new StringBuilder(timeRange);
+				for (String execLine : execLines)
+					tip.append("<br>").append(execLine);
+				sbTips.append("    '").append(tip).append("'");
+			}
+		}
+		sbTips.append("\n];");
+
+		StringBuilder jsSb = new StringBuilder();
+		jsSb.append("<script type='text/javascript'>\n");
+		jsSb.append("\n");
+		jsSb.append(sbTips).append("\n");
+		jsSb.append("\n");
+		jsSb.append("    sparklineListToLoad.push('" + sparklineClassName + "');\n");
+		jsSb.append("\n");
+		jsSb.append("    sparklineConfMap.set('" + sparklineClassName + "', {\n");
+		jsSb.append("        type: 'bar',\n");
+		jsSb.append("        barColor: '#4682B4',\n");
+		jsSb.append("        colorMap: " + sbColorMap + ",\n");
+		jsSb.append("        zeroColor: 'transparent',\n");
+		jsSb.append("        nullColor: 'transparent',\n");
+		jsSb.append("        chartRangeMin: 0,\n");
+		jsSb.append("        barWidth: 1,\n");
+		jsSb.append("        barSpacing: 0,\n");
+		jsSb.append("        tooltipFormatter: function(sp, opts, fields) {\n");
+		jsSb.append("            var f = Array.isArray(fields) ? fields[0] : fields;\n");
+		jsSb.append("            if (!f) return '';\n");
+		jsSb.append("            var t = " + jsVarName + "[f.offset];\n");
+		jsSb.append("            return (t && t.length > 0) ? '<span style=\"font-size:12px;\">' + t + '</span>' : '';\n");
+		jsSb.append("        }\n");
+		jsSb.append("    });\n");
+		jsSb.append("\n");
+		jsSb.append("</script>\n");
+		_miniChartJsList.add(jsSb.toString());
+	}
+
+
 	private void createSparklineForHistoryExecutions(String textToParse, ResultSetTableModel rstm, int row, String colName)
 	{
 		List<String> lines = Arrays.asList(StringUtils.split(textToParse, "\n"));

--- a/src/com/dbxtune/utils/Configuration.java
+++ b/src/com/dbxtune/utils/Configuration.java
@@ -67,6 +67,7 @@ import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1072,6 +1073,52 @@ extends Properties
 	}
 
 	/**
+	 * Returns the unique key prefixes matching the specified prefix.
+	 * <p>
+	 * For each property key that starts with {@code prefix}, the portion of the
+	 * key up to the first {@code '.'} separator is returned. The resulting names
+	 * are unique and sorted in ascending order.
+	 * <p>
+	 * For example, given the following properties:
+	 *
+	 * <pre>
+	 * CmName1.prop1 = value
+	 * CmName1.prop2 = value
+	 * CmName2.prop1 = value
+	 * CmName2.prop2 = value
+	 * CmName3.prop1 = value
+	 * </pre>
+	 *
+	 * Calling:
+	 *
+	 * <pre>
+	 * getUniqueKeys("Cm")
+	 * </pre>
+	 *
+	 * returns:
+	 *
+	 * <pre>
+	 * [CmName1, CmName2, CmName3]
+	 * </pre>
+	 *
+	 * @param prefix the key prefix to match
+	 * @return a sorted list of unique key prefixes
+	 */
+	public List<String> getUniqueKeys(String prefix) 
+	{
+		return this.stringPropertyNames().stream()
+			.filter(key -> key.startsWith(prefix))
+//			.map(key -> key.substring(prefix.length()))
+			.map(key -> {
+				int idx = key.indexOf('.');
+				return idx >= 0 ? key.substring(0, idx) : key;
+			})
+			.distinct()
+			.sorted()
+			.collect(Collectors.toList());   // Java 11
+	}
+
+	/**
 	 * Get the list of unique sub-keys contained in the configuration repository that
 	 * match the specified prefix.
 	 * <p>
@@ -1247,6 +1294,17 @@ extends Properties
 		String newKey = key + ".[" + monitorProp + "]";
 		
 		return setProperty(newKey, val);
+	}
+	
+	/**
+	 * Calls super.getProperty(propName)
+	 * 
+	 * @param propName
+	 * @return
+	 */
+	public String getPropertySuper(String propName)
+	{
+		return super.getProperty(propName);
 	}
 
 	/** Get a int value for property */
@@ -2061,9 +2119,10 @@ extends Properties
 		writeln(bw, "#=======================================================");
 		if (s != null)
 		{
-		writeln(bw, "# " + s);
+			writeln(bw, "# " + s);
 		}
-		writeln(bw, "# Last save time: "+new Date().toString());
+//		writeln(bw, "# Last save time: "+new Date().toString());
+		writeln(bw, "# Last save time: " + TimeUtils.toStringYmdHms(System.currentTimeMillis()));
 		writeln(bw, "#-------------------------------------------------------");
 		writeln(bw, "");
 
@@ -2202,7 +2261,7 @@ extends Properties
 				outBuffer.append('f');
 				break;
 			case '=': // Fall through
-			case ':': // Fall through
+			case ':': // Fall through  -- POSSIBLY: do we need this ???  possibly just comment it out... BUT: We need to test load() so we don't break that
 			case '#': // Fall through
 			case '!':
 				outBuffer.append('\\');
@@ -2539,6 +2598,7 @@ extends Properties
 			Collections.sort(matchingKeys);
 			return matchingKeys;
 		}
+
 		@Override
 		public List<String> getKeys()
 		{

--- a/src/com/dbxtune/utils/MailUtil.java
+++ b/src/com/dbxtune/utils/MailUtil.java
@@ -161,14 +161,20 @@ public class MailUtil
 			if (StringUtil.hasValue(config.from))
 				applyFromAddress(email, config.from);
 
-			_logger.info("MailUtil.createHtmlEmail(): configPrefix='{}', host='{}', port={}, sslPort={}, useSsl={}, startTls={}, startTlsRequired={}, connTimeoutSec={}, from='{}', hasAuth={}",
+			_logger.info("MailUtil.createHtmlEmail(): configPrefix='{}', host='{}', port={}, sslPort={}, useSsl={}, startTls={}, startTlsRequired={}, connTimeoutSec={}, from='{}', to='{}', hasAuth={}",
 					config.resolvedPrefix,
-					config.smtpHostname, config.smtpPort, config.sslPort,
-					config.useSsl, config.startTls, config.startTlsRequired,
-					config.connectionTimeout, config.from,
+					config.smtpHostname, 
+					config.smtpPort, 
+					config.sslPort,
+					config.useSsl, 
+					config.startTls, 
+					config.startTlsRequired,
+					config.connectionTimeout, 
+					config.from,
+					config.to,
 					StringUtil.hasValue(config.username));
 
-			return new MailBuilder(email);
+			return new MailBuilder(config, email);
 		}
 		catch (EmailException e)
 		{
@@ -259,22 +265,34 @@ public class MailUtil
 	{
 		/** {@code .smtp.hostname} — SMTP server hostname */
 		public static final String SUFFIX_SMTP_HOST         = ".smtp.hostname";
+
 		/** {@code .smtp.port} — SMTP port (-1 = use default) */
 		public static final String SUFFIX_SMTP_PORT         = ".smtp.port";
+
 		/** {@code .ssl.port} — SSL port (-1 = use default) */
 		public static final String SUFFIX_SSL_PORT          = ".ssl.port";
+
 		/** {@code .smtp.username} — SMTP authentication username */
 		public static final String SUFFIX_USERNAME          = ".smtp.username";
+
 		/** {@code .smtp.password} — SMTP authentication password */
 		public static final String SUFFIX_PASSWORD          = ".smtp.password";
+
+		/** {@code .to} — to address */
+		public static final String SUFFIX_TO                = ".to";
+
 		/** {@code .from} — sender address, may include display name: {@code "Name <email>"} */
 		public static final String SUFFIX_FROM              = ".from";
+
 		/** {@code .ssl.use} — enable SSL-on-connect */
 		public static final String SUFFIX_USE_SSL           = ".ssl.use";
+
 		/** {@code .start.tls} — enable STARTTLS (opportunistic) */
 		public static final String SUFFIX_START_TLS         = ".start.tls";
+
 		/** {@code .start.tls.required} — require STARTTLS (fail if not available; useful for O365) */
 		public static final String SUFFIX_START_TLS_REQ     = ".start.tls.required";
+
 		/** {@code .smtp.connect.timeout} — socket connection timeout in <b>seconds</b> (-1 = default) */
 		public static final String SUFFIX_CONN_TIMEOUT      = ".smtp.connect.timeout";
 
@@ -286,6 +304,7 @@ public class MailUtil
 		public int     sslPort           = -1;
 		public String  username          = "";
 		public String  password          = "";
+		public String  to                = "";
 		public String  from              = "";
 		public boolean useSsl            = false;
 		public boolean startTls          = false;
@@ -315,16 +334,18 @@ public class MailUtil
 			MailConfig c          = new MailConfig();
 			c.resolvedPrefix      = prefix;
 
-			c.smtpHostname = str (conf, prefix, SUFFIX_SMTP_HOST,     "",    useFallback);
-			c.smtpPort     = iget(conf, prefix, SUFFIX_SMTP_PORT,     -1,    useFallback);
-			c.sslPort      = iget(conf, prefix, SUFFIX_SSL_PORT,      -1,    useFallback);
-			c.username     = str (conf, prefix, SUFFIX_USERNAME,      "",    useFallback);
-			c.password     = str (conf, prefix, SUFFIX_PASSWORD,      "",    useFallback);
-			c.from         = str (conf, prefix, SUFFIX_FROM,          "",    useFallback);
-			c.useSsl       = bget(conf, prefix, SUFFIX_USE_SSL,       false, useFallback);
-			c.startTls     = bget(conf, prefix, SUFFIX_START_TLS,     false, useFallback);
-			c.startTlsRequired = bget(conf, prefix, SUFFIX_START_TLS_REQ, false, useFallback);
-			c.connectionTimeout = iget(conf, prefix, SUFFIX_CONN_TIMEOUT, -1, useFallback);
+			c.smtpHostname      = str (conf, prefix, SUFFIX_SMTP_HOST,     "",    useFallback);
+			c.smtpPort          = iget(conf, prefix, SUFFIX_SMTP_PORT,     -1,    useFallback);
+			c.sslPort           = iget(conf, prefix, SUFFIX_SSL_PORT,      -1,    useFallback);
+			c.username          = str (conf, prefix, SUFFIX_USERNAME,      "",    useFallback);
+			c.password          = str (conf, prefix, SUFFIX_PASSWORD,      "",    useFallback);
+			c.to                = str (conf, prefix, SUFFIX_TO,            "",    useFallback);
+			c.from              = str (conf, prefix, SUFFIX_FROM,          "",    useFallback);
+			c.useSsl            = bget(conf, prefix, SUFFIX_USE_SSL,       false, useFallback);
+			c.startTls          = bget(conf, prefix, SUFFIX_START_TLS,     false, useFallback);
+			c.startTlsRequired  = bget(conf, prefix, SUFFIX_START_TLS_REQ, false, useFallback);
+			c.connectionTimeout = iget(conf, prefix, SUFFIX_CONN_TIMEOUT,  -1,    useFallback);
+
 			return c;
 		}
 
@@ -377,10 +398,18 @@ public class MailUtil
 	public static class MailBuilder
 	{
 		private final HtmlEmail _email;
+		private final MailConfig _mailConfig;
 
-		MailBuilder(HtmlEmail email)
+		MailBuilder(MailConfig mailConfig, HtmlEmail email)
 		{
-			_email = email;
+			_mailConfig = mailConfig;
+			_email      = email;
+		}
+
+		/** Return the underlying {@link MailConfig} for advanced/low-level use. */
+		public MailConfig getMailConfig()
+		{
+			return _mailConfig;
 		}
 
 		/** Return the underlying {@link HtmlEmail} for advanced/low-level use. */
@@ -515,6 +544,17 @@ public class MailUtil
 		{
 			try
 			{
+				// If no TO address has been given, set the "to" from the MailConfig
+				if (_email.getToAddresses() == null || _email.getToAddresses().isEmpty()) 
+				{
+					if (getMailConfig() != null)
+					{
+						String toAddress = getMailConfig().to;
+						if (StringUtil.hasValue(toAddress))
+							_email.addTo(_mailConfig.to);
+					}
+				}
+
 				return _email.send();
 			}
 			catch (EmailException e)


### PR DESCRIPTION
Generic
 * Menu -- Tools -- 'Create Record Session - Template file' Wizard...' now writes a template file with comments (and all default values are commented out). You can choose to sort the CM Entries by name or have it in creation order!
 * PCS Writers now also Writes "Target Info: <where did we store the data>" in the log file (for tracability)
 * AppDir got some improvements for the upcomming Windows: DbxInstaller
 * MailUtil: If no 'to' address has been given, fallback on property '{cfgName|mail}.to'

DbxCentral
 * Counter Details -- Remember current tab name within a "tab group" (move more fluently between tabs, and remember the last visited CM)

SqlServerTune
 * Daily Summary Report -- SqlServerJobScheduler -- Added column 'scheduledLast24hChart', which is a "gantt" that tries to visualize when a job was executed during the day.