### PR TITLE
Small change

### DIFF
--- a/resources/WebContent/scripts/dbxtune/js/dbxcentral.graph.js
+++ b/resources/WebContent/scripts/dbxtune/js/dbxcentral.graph.js
@@ -697,6 +697,135 @@ setTimeout(function()
 }, 10);
 
 
+//-----------------------------------------------------------
+// ACTIVE STATEMENTS: Collector-problem indicator
+//-----------------------------------------------------------
+// DbxCmLastSampleJson/DbxCmHistorySampleJson only get a row written for
+// 'CmActiveStatements' when the collector actually produced rows that cycle
+// (see CentralPersistWriterJdbc.saveCmJsonCounters()). When the collector fails
+// (e.g. a SQLTimeoutException against the monitored DBMS), no row is written at
+// all, so the panel would otherwise just silently show stale/no data.
+//
+// "Counter Details" already solves this for other CMs by live-proxying to the
+// collector itself via /api/cc/mgt/cm/list (see dbxGraphCounterDetails.js) --
+// that response already includes exceptionMsg/exceptionFullText for CmActiveStatements
+// whenever it had a problem. We reuse that same endpoint here.
+
+// srvName -> { exceptionMsg, exceptionFullText } | { offline:true, message } | (absent = OK)
+var _asCollectorProblems = {};
+// Last successfully parsed /api/last-sample or /api/history-sample payload, so a
+// collector-problem state change alone can trigger a re-render without waiting
+// for new counter data.
+var _asLastAllEntries = null;
+
+/** Parse a /api/cc/mgt/cm/list response body into a collector-problem descriptor, or undefined if none. */
+function _asParseCollectorProblemFromCmList(bodyText)
+{
+	try
+	{
+		var r = JSON.parse(bodyText);
+		if (r.error)
+		{
+			// e.g. "collector-offline", "srv-not-found" -- the proxy couldn't reach/resolve the collector
+			return { offline: true, message: r.message || r.error };
+		}
+		if (r.groups)
+		{
+			for (var g=0; g<r.groups.length; g++)
+			{
+				var cms = (r.groups[g] && r.groups[g].cms) || [];
+				for (var c=0; c<cms.length; c++)
+				{
+					if (cms[c].cmName === "CmActiveStatements" && cms[c].exceptionMsg)
+						return { exceptionMsg: cms[c].exceptionMsg, exceptionFullText: cms[c].exceptionFullText };
+				}
+			}
+		}
+	}
+	catch (ex)
+	{
+		console.log("_asParseCollectorProblemFromCmList(): failed to parse response: " + ex, bodyText);
+	}
+	return undefined; // no problem found
+}
+
+/**
+ * Live-check every server in '_serverList' for a CmActiveStatements collector problem,
+ * via the same '/api/cc/mgt/cm/list' proxy endpoint "Counter Details" uses. Updates
+ * '_asCollectorProblems' and calls 'doneCallback(changed)' once all servers responded.
+ */
+function _asRefreshCollectorProblems(timeStr, doneCallback)
+{
+	if ( ! _serverList || _serverList.length === 0)
+	{
+		if (typeof doneCallback === "function") doneCallback(false);
+		return;
+	}
+
+	var pending = _serverList.length;
+	var changed = false;
+
+	_serverList.forEach(function(srvName)
+	{
+		$.ajax({
+			url: "/api/cc/mgt/cm/list",
+			data: { srv: srvName, time: timeStr },
+			dataType: "text",
+			complete: function(xhr)
+			{
+				var newVal = (xhr.status === 0)
+					? { offline: true, message: "Network error contacting DbxCentral" }
+					: _asParseCollectorProblemFromCmList(xhr.responseText);
+
+				if (JSON.stringify(_asCollectorProblems[srvName]) !== JSON.stringify(newVal))
+					changed = true;
+
+				if (newVal === undefined) delete _asCollectorProblems[srvName];
+				else                       _asCollectorProblems[srvName] = newVal;
+
+				pending--;
+				if (pending <= 0 && typeof doneCallback === "function")
+					doneCallback(changed);
+			}
+		});
+	});
+}
+
+/** Build the same "Collector problem at sample time" warning banner Counter Details uses (dbxGraphCounterDetails.js). */
+function _asBuildCollectorProblemBanner(srvName, problem)
+{
+	var div = document.createElement("div");
+	// Override Bootstrap's '.alert' default margin-bottom:1rem (which otherwise stacks with
+	// the per-server '<br>' spacer and shows up as an oversized gap above whatever follows --
+	// the table, or the next server's "Active Statements on server:" label).
+	div.style.margin = "4px 0";
+
+	if (problem.offline)
+	{
+		div.className = "alert alert-secondary";
+		div.style.fontSize = "0.85em";
+		div.innerHTML = "<strong>&#9888; Collector unreachable</strong><br>"
+			+ "Could not reach the collector for server '" + $("<span>").text(srvName).html() + "' to check for problems."
+			+ (problem.message ? ("<br><span style='opacity:0.8'>" + $("<span>").text(problem.message).html() + "</span>") : "");
+		return div;
+	}
+
+	div.className = "alert alert-warning";
+	div.style.fontSize = "0.85em";
+	var html = "<strong>&#9888; Collector problem at sample time</strong><br>"
+		+ $("<span>").text(problem.exceptionMsg).html();
+
+	if (problem.exceptionFullText)
+	{
+		html += "<br><details style='margin-top:4px'><summary style='cursor:pointer;'>Full stack trace</summary>"
+			+ "<pre style='font-size:0.8em;white-space:pre-wrap;margin-top:4px;'>" + $("<span>").text(problem.exceptionFullText).html() + "</pre></details>";
+	}
+
+	div.innerHTML = html;
+	return div;
+}
+
+
 /**
  * Get Active Statements saved in the Central PCS (last known/received values)
  */
@@ -720,13 +849,22 @@ function dbxTuneCheckActiveStatements()
 		console.log("dbxTuneCheckActiveStatements(): Found " + _serverList.length + " entries in the serverlist. ONLY FIRST WILL BE CHECKED. _serverList=" + _serverList);
 	}
 
+	// Live-check each collector for a CmActiveStatements problem (see _asRefreshCollectorProblems()
+	// above) -- catches the case where the collector failed and no new sample was ever written,
+	// which otherwise looks identical to "no active statements" or "nothing changed".
+	_asRefreshCollectorProblems(moment().format('YYYY-MM-DD HH:mm:ss'), function(changed)
+	{
+		if (changed && _asLastAllEntries)
+			setActiveStatement(_asLastAllEntries);
+	});
+
 	$.ajax(
 	{
 		url: "/api/last-sample?srv="+srvName+"&cm=CmActiveStatements",
 		type: 'get',
 		//async: false,   // to call it one by one (async: true = spawn away a bunch of them in the background)
-			
-		success: function(data, status) 
+
+		success: function(data, status)
 		{
 			console.log("DEBUG: dbxTuneCheckActiveStatements(): CALL SUCCESS...");
 		//	console.log("DEBUG: dbxTuneCheckActiveStatements(): CALL SUCCESS... data & _lastActiveStatementData", data, _lastActiveStatementData);
@@ -740,11 +878,12 @@ function dbxTuneCheckActiveStatements()
 				return;
 			}
 			_lastActiveStatementData = data;
-			
+
 			var jsonResp = JSON.parse(data);
 			console.log("RECEIVED DATA[dbxTuneCheckActiveStatements]: ", jsonResp);
 
-			setActiveStatement(jsonResp); 
+			_asLastAllEntries = jsonResp;
+			setActiveStatement(jsonResp);
 		},
 		error: function(xhr, desc, err) 
 		{
@@ -781,11 +920,19 @@ function dbxTuneGetHistoryStatements(startTime, endTime)
 	             + "&endTime="    + endTime
 	             + "";
 	console.log("dbxTuneGetHistoryStatements(): Calling url '" + urlStr + "'.");
-	
+
 	// Show info that we are getting data (this might be slow), only disaply after x ms
 	// And in the below SUCCESS/FAIL -- CLOSE the info field/popup
 //	document.getElementById("dbx-history-get-data-bussy").style.visibility = 'visible';
 	var dbxHistoryGetDataBussyTime = setTimeout(function() { document.getElementById("dbx-history-get-data-bussy").style.visibility = 'visible'; }, 20);
+
+	// Live-check each collector for a CmActiveStatements problem at this point in history (same
+	// idea as dbxTuneCheckActiveStatements() -- see _asRefreshCollectorProblems() above).
+	_asRefreshCollectorProblems(startTime, function(changed)
+	{
+		if (changed && _asLastAllEntries)
+			setActiveStatement(_asLastAllEntries);
+	});
 
 	// GET Data
 	$.ajax(
@@ -810,11 +957,12 @@ function dbxTuneGetHistoryStatements(startTime, endTime)
 //				return;
 //			}
 			_lastActiveStatementData = data;
-			
+
 			var jsonResp = JSON.parse(data);
 			console.log("RECEIVED DATA[dbxTuneGetHistoryStatements]: ", jsonResp);
 
-			setHistoryStatement(jsonResp); 
+			_asLastAllEntries = jsonResp;
+			setHistoryStatement(jsonResp);
 
 			// CLOSE the info field (that we are getting data from the DB)
 			clearTimeout(dbxHistoryGetDataBussyTime);
@@ -2258,8 +2406,30 @@ function dbxTuneGraphSubscribe()
 	/**
 	 * INTERNAL: buildActiveStatementDiv
 	 */
-	function buildActiveStatementDiv(appName, srvName, counters)
+	function buildActiveStatementDiv(appName, srvName, counters, collectorProblem)
 	{
+		// No sample data at all for this server (either the collector has never produced a
+		// valid CmActiveStatements row, or this is a synthetic problem-only entry) -- if we
+		// also know *why* (collectorProblem), just show that instead of an empty/broken table.
+		var hasCounterData = counters && Array.isArray(counters.rateCounters);
+		if (collectorProblem && ! hasCounterData)
+		{
+			var problemOnlyDiv = document.createElement("div");
+			problemOnlyDiv.setAttribute("id",    "active-statements-srv-" + srvName);
+			problemOnlyDiv.setAttribute("class", "active-statements-srv-class");
+			problemOnlyDiv.style.marginTop = "8px"; // spacer between server blocks, instead of a full <br> line
+			problemOnlyDiv.statementsRowCount = 0;
+
+			var infoDivPO = document.createElement("div");
+			infoDivPO.innerHTML = "Active Statements on server: <b>" + srvName + "</b>";
+			infoDivPO.setAttribute("class", "active-statements-srv-info-class");
+
+			problemOnlyDiv.appendChild(infoDivPO);
+			problemOnlyDiv.appendChild(_asBuildCollectorProblemBanner(srvName, collectorProblem));
+
+			return problemOnlyDiv;
+		}
+
 		// Get what Type we want to view: ABS, DIFF or RATE
 		var counterData = counters.rateCounters;
 		var selectedCounterType = document.querySelector('input[name="active-statements-counter-type"]:checked').value;
@@ -2615,6 +2785,7 @@ function dbxTuneGraphSubscribe()
 		newSrvDiv.setAttribute("id",    "active-statements-srv-" + srvName);
 		newSrvDiv.setAttribute("class", "active-statements-srv-class");
 		newSrvDiv.setAttribute("title", tooltip);
+		newSrvDiv.style.marginTop = "8px"; // spacer between server blocks, instead of a full <br> line
 
 		
 		// "add" a property 'statementsRowCount' to a div the we read later.
@@ -2666,8 +2837,9 @@ function dbxTuneGraphSubscribe()
 
 
 		// Add stuff to the 'newSrvDiv'
-		newSrvDiv.appendChild(document.createElement("br"));
 		newSrvDiv.appendChild(newSrvInfoDiv);
+		if (collectorProblem)
+			newSrvDiv.appendChild(_asBuildCollectorProblemBanner(srvName, collectorProblem));
 		newSrvDiv.appendChild(newSrvTabDiv);
 //		newSrvDiv.appendChild(tab);
 //		newSrvDiv.appendChild(document.createElement("br"));
@@ -2702,6 +2874,10 @@ function dbxTuneGraphSubscribe()
 		// Keep count on TOTAL active statements (in all servers)
 		var totalActiveStatementsCount = 0;
 
+		// Track which servers we've built a div for, so a collector-problem-only server (one
+		// that never made it into 'allEntries' because it never produced a valid sample) still
+		// gets a div below with just the warning banner.
+		var srvNamesSeen = {};
 
 		// Loop all entries
 		// Build a "div" foreach of the servers that has active statements
@@ -2714,20 +2890,30 @@ function dbxTuneGraphSubscribe()
 
 			var appName = entry.appName;
 			var srvName = entry.srvName;
-			
+			srvNamesSeen[srvName] = true;
+
 			var counters = {};
 			for(let c=0; c<entry.cmNames.length; c++)
 			{
 				var cmNamesEntry = entry.cmNames[c];
-					
+
 				if (cmNamesEntry.cmName === "CmActiveStatements")
 					counters = cmNamesEntry.lastSample.counters;
 			}
-			
-			var newSrvDiv = buildActiveStatementDiv(appName, srvName, counters);
-			
+
+			var newSrvDiv = buildActiveStatementDiv(appName, srvName, counters, _asCollectorProblems[srvName]);
+
 			// Push the new div on the array, which will be read later
 			activeStatementsDivArr.push(newSrvDiv);
+		}
+
+		// Servers with a currently-known collector problem that never showed up above (the
+		// collector has never produced a valid CmActiveStatements sample at all).
+		for (var problemSrvName in _asCollectorProblems)
+		{
+			if (srvNamesSeen[problemSrvName]) continue;
+			var problemSrvDiv = buildActiveStatementDiv("Unknown", problemSrvName, {}, _asCollectorProblems[problemSrvName]);
+			activeStatementsDivArr.push(problemSrvDiv);
 		}
 
 		// Emty the Statements Window
@@ -2765,10 +2951,15 @@ function dbxTuneGraphSubscribe()
 		// Set count at the top of the poupup window
 		$("#active-statements-count").html(totalActiveStatementsCount);
 
+		// A collector problem should draw the same attention as active statements do, even
+		// when the current row count is 0 -- which is exactly the case a collector problem
+		// (no valid sample this cycle) very often causes.
+		var hasAnyCollectorProblem = Object.keys(_asCollectorProblems).length > 0;
+
 		// Floating button: update badge count and blink when active
-		if ( totalActiveStatementsCount > 0 )
+		if ( totalActiveStatementsCount > 0 || hasAnyCollectorProblem )
 		{
-			$("#active-stmt-count").text(totalActiveStatementsCount).show();
+			$("#active-stmt-count").text( totalActiveStatementsCount > 0 ? totalActiveStatementsCount : "!" ).show();
 			$("#active-statements-btn").css("animation", "blink 1.5s infinite");
 			$("#active-statements-btn").css("background", "rgba(229, 228, 226, 0.5)");
 		}
@@ -2783,7 +2974,7 @@ function dbxTuneGraphSubscribe()
 		// SHOW all Statements div
 		if ( document.getElementById("active-statements-auto-open-chk").checked )
 		{
-			if ( totalActiveStatementsCount > 0 )
+			if ( totalActiveStatementsCount > 0 || hasAnyCollectorProblem )
 				$("#active-statements").css("display", "block"); // show
 			else
 				$("#active-statements").css("display", "none"); // hide

--- a/src/com/dbxtune/Version.java
+++ b/src/com/dbxtune/Version.java
@@ -31,10 +31,10 @@ public class Version
 {
 	public static       String PRODUCT_STRING     = "DbxTune";      // Do not have spaces etc in this one
 //	public static final String VERSION_STRING     = "4.6.0";        // Use this for public releases
-	public static final String VERSION_STRING     = "4.6.0.68.dev"; // Use this for early releases
-	public static final String BUILD_STRING       = "2026-07-25/build 618";
+	public static final String VERSION_STRING     = "4.6.0.69.dev"; // Use this for early releases
+	public static final String BUILD_STRING       = "2026-08-11/build 619";
 
-	public static final String GIT_DATE_STRING    = "2026-07-25";  // try to update this
+	public static final String GIT_DATE_STRING    = "2026-08-11";  // try to update this
 	public static final String GIT_REVISION_STR   = "610";         // used by CheckForUpdates --- update this on every check-in (emulates Subversion "Revision:" tag)
 
 	public static final boolean IS_DEVELOPMENT_VERSION  = true; // if true: date expiration will be checked on startup

--- a/src/com/dbxtune/cm/ase/CmOpenDatabases.java
+++ b/src/com/dbxtune/cm/ase/CmOpenDatabases.java
@@ -2109,13 +2109,40 @@ extends CountersModel
 
 					if (val.intValue() > threshold)
 					{
-						// Guess what TYPE of dump that went wrong
-						String backupType = "-UNKNOWN-TYPE-"; // 'DB' or 'TRAN'
-						if (cm.hasColumns("BackupStartTime", "LastTranLogDumpTime"))
+						// Guess what TYPE of dump that went wrong: 'DB', 'TRAN', 'BOTH' or unknown
+						String backupType = "-UNKNOWN-TYPE-";
+						if (cm.hasColumns("BackupEndTime", "LastTranLogEndDumpTime"))
 						{
+							// 'BackupEndTime' is ONLY moved forward on a *successful* db dump, so it stays
+							// frozen at the last success if the most recent db dump attempt failed.
+							// 'LastTranLogEndDumpTime' on the other hand always advances (success or failure),
+							// so a failed tran dump can only be inferred by elimination.
+							Timestamp backupStartTime     = cm.getAbsValueAsTimestamp(r, "BackupStartTime");
+							Timestamp backupEndTime       = cm.getAbsValueAsTimestamp(r, "BackupEndTime");
+							Timestamp lastTranLogDumpTime = cm.getAbsValueAsTimestamp(r, "LastTranLogDumpTime");
+
+							Double  backupInProgressVal = cm.getAbsValueAsDouble(r, "BackupInProgress");
+							boolean backupInProgress    = backupInProgressVal != null && backupInProgressVal.intValue() > 0;
+
+							boolean dbDumpUnfinished = backupStartTime != null
+									&& (backupEndTime == null || backupStartTime.after(backupEndTime))
+									&& !backupInProgress;
+
+							boolean mostRecentIsTran = lastTranLogDumpTime != null
+									&& (backupStartTime == null || lastTranLogDumpTime.after(backupStartTime));
+
+							if      (dbDumpUnfinished && mostRecentIsTran) backupType = "BOTH";
+							else if (dbDumpUnfinished)                     backupType = "DB";
+							else if (lastTranLogDumpTime != null)          backupType = "TRAN";
+						}
+						else if (cm.hasColumns("BackupStartTime", "LastTranLogDumpTime"))
+						{
+							// Legacy heuristic for ASE versions older than 16.0 SP4 PL1, where
+							// 'BackupEndTime'/'LastTranLogEndDumpTime' aren't available: whichever
+							// dump was started more recently is assumed to be the one that failed.
 							Timestamp backupStartTime     = cm.getAbsValueAsTimestamp(r, "BackupStartTime");
 							Timestamp lastTranLogDumpTime = cm.getAbsValueAsTimestamp(r, "LastTranLogDumpTime");
-							
+
 							if (backupStartTime != null && lastTranLogDumpTime != null)
 							{
 								if (backupStartTime.getTime() >= lastTranLogDumpTime.getTime())
@@ -2130,29 +2157,38 @@ extends CountersModel
 							}
 						}
 
-						// Create the Alarm
+						// Create the Alarm(s)
 						String extendedDescText = cm.toTextTableString(DATA_RATE, r);
 						String extendedDescHtml = cm.toHtmlTableString(DATA_RATE, r, true, false, false);
 
-						AlarmEvent ae;
-						if ("DB".equals(backupType))
+						List<AlarmEvent> alarmEvents = new ArrayList<>();
+						if ("BOTH".equals(backupType))
 						{
-							ae = new AlarmEventLastDbBackupFailed(cm, dbname, threshold);
+							alarmEvents.add(new AlarmEventLastDbBackupFailed(cm, dbname, threshold));
+							alarmEvents.add(new AlarmEventLastWalBackupFailed(cm, dbname, threshold));
 						}
-						else if ("TRAN".equals(backupType)) 
+						else if ("DB".equals(backupType))
 						{
-							ae = new AlarmEventLastWalBackupFailed(cm, dbname, threshold);
+							alarmEvents.add(new AlarmEventLastDbBackupFailed(cm, dbname, threshold));
+						}
+						else if ("TRAN".equals(backupType))
+						{
+							alarmEvents.add(new AlarmEventLastWalBackupFailed(cm, dbname, threshold));
 						}
 						else
 						{
-							ae = new AlarmEventLastBackupFailed(cm, dbname, backupType, threshold);
+							alarmEvents.add(new AlarmEventLastBackupFailed(cm, dbname, backupType, threshold));
 						}
-						ae.setExtendedDescription(extendedDescText, extendedDescHtml);
 
-						// Information about how to disable this alarm
-						ae.createAlarmOptionsMessage(this, "LastBackupFailed");
+						for (AlarmEvent ae : alarmEvents)
+						{
+							ae.setExtendedDescription(extendedDescText, extendedDescHtml);
 
-						alarmHandler.addAlarm( ae );
+							// Information about how to disable this alarm
+							ae.createAlarmOptionsMessage(this, "LastBackupFailed");
+
+							alarmHandler.addAlarm( ae );
+						}
 					}
 				}
 			}

--- a/src/com/dbxtune/cm/sqlserver/CmErrorLog.java
+++ b/src/com/dbxtune/cm/sqlserver/CmErrorLog.java
@@ -27,7 +27,9 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,6 +42,9 @@ import com.dbxtune.alarm.events.AlarmEventConfigChanges;
 import com.dbxtune.alarm.events.AlarmEventConfigResourceIsUsedUp;
 import com.dbxtune.alarm.events.AlarmEventErrorLogEntry;
 import com.dbxtune.alarm.events.AlarmEventFullTranLog;
+import com.dbxtune.alarm.events.AlarmEventLastBackupFailed;
+import com.dbxtune.alarm.events.AlarmEventLastDbBackupFailed;
+import com.dbxtune.alarm.events.AlarmEventLastWalBackupFailed;
 import com.dbxtune.alarm.events.sqlserver.AlarmEventStackDump;
 import com.dbxtune.cm.CmSettingsHelper;
 import com.dbxtune.cm.CounterSetTemplates;
@@ -277,6 +282,9 @@ extends CountersModelAppend
 
 		boolean debugPrint = Configuration.getCombinedConfiguration().getBooleanProperty("sendAlarmRequest.debug", _logger.isDebugEnabled());
 		
+		CountersModel cm = this;
+//		String dbmsSrvName = cm.getServerName();
+
 		// ABS Data from LAST refresh only
 		List<List<Object>> lastRefreshRows = getDataCollectionForLastRefresh();
 
@@ -301,7 +309,7 @@ extends CountersModelAppend
 			return;
 
 		int col_LogDate_pos     = findColumn("LogDate");
-//		int col_ProcessInfo_pos = findColumn("ProcessInfo");
+		int col_ProcessInfo_pos = findColumn("ProcessInfo");
 		int col_Text_pos        = findColumn("Text");
 
 //		if (col_LogDate_pos < 0 || col_ProcessInfo_pos < 0 || col_Text_pos < 0)
@@ -312,6 +320,11 @@ extends CountersModelAppend
 		if (col_LogDate_pos < 0)
 		{
 			_logger.error("When checking for alarms, could not find all columns. skipping this. [LogDate_pos="+col_LogDate_pos+"]");
+			return;
+		}
+		if (col_ProcessInfo_pos < 0)
+		{
+			_logger.error("When checking for alarms, could not find all columns. skipping this. [ProcessInfo_pos="+col_ProcessInfo_pos+"]");
 			return;
 		}
 		if (col_Text_pos < 0)
@@ -342,10 +355,18 @@ extends CountersModelAppend
 				continue;
 			}
 
-			Timestamp errorlogTs = (Timestamp) o_LogDate;
-			String    errorTxt   = (String)    o_Text;
-			int       errorNum   = -1;
-			int       severity   = -1;
+			Object o_ProcessInfo = row.get(col_ProcessInfo_pos);
+			if (o_ProcessInfo == null || !(o_ProcessInfo instanceof String) )
+			{
+				_logger.error("When checking for alarms, the column 'ProcessInfo' is NOT an String, skipping this row.");
+				continue;
+			}
+
+			Timestamp errorlogTs  = (Timestamp) o_LogDate;
+			String    errorTxt    = (String)    o_Text;
+			String    processInfo = (String)    o_ProcessInfo;
+			int       errorNum    = -1;
+			int       severity    = -1;
 
 			// Error: 911, Severity: 16, State: 1.
 			if (errorTxt.startsWith("Error: "))
@@ -661,37 +682,125 @@ extends CountersModelAppend
 				}
 			}
 
+			//-------------------------------------------------------
+			// DB/WAL -- DATABASE Backup FAILED -- Error 3041
+			//-------------------------------------------------------
+			if ("Backup".equals(processInfo))
+			{
+				// Error: 3041, Severity: 16, State: 1.
+				// BACKUP failed to complete the command BACKUP DATABASE ${dbname}. Check the backup application log for detailed messages.
+				// BACKUP failed to complete the command BACKUP DATABASE ${dbname} WITH DIFFERENTIAL. Check the backup application log for detailed messages.
+				// BACKUP failed to complete the command BACKUP LOG ${dbname}. Check the backup application log for detailed messages.
+				if (errorNum == 3041 && isSystemAlarmsForColumnEnabledAndInTimeRange("LastBackupFailed"))
+				{
+					String dbname     = "-unknown-";
+					String backupType = "-unknown-";
+					int threshold = 1;
+
+					if (errorTxt.startsWith("BACKUP failed to complete the command BACKUP "))
+					{
+						if (errorTxt.contains(" BACKUP DATABASE "))
+						{
+							backupType = "DB";
+							dbname     = StringUtils.trim( StringUtils.substringBetween(errorTxt, " BACKUP DATABASE ", ". Check the") );
+
+							// Remove/replace some specific "known" words from the parsed database name 
+							if (dbname != null && dbname.contains("WITH DIFFERENTIAL"))
+							{
+								dbname = dbname.replace("WITH DIFFERENTIAL", "").trim();
+							}
+						}
+
+						if (errorTxt.contains(" BACKUP LOG "))
+						{
+							backupType = "WAL";
+							dbname     = StringUtils.trim( StringUtils.substringBetween(errorTxt, " BACKUP LOG ", ". Check the") );;
+						}
+					}
+
+					AlarmEvent ae = null;
+					
+					//--------------------------------------------------------
+					// DATABASE Backup FAILED
+					//--------------------------------------------------------
+					if ("DB".equals(backupType))
+					{
+						ae = new AlarmEventLastDbBackupFailed(cm, dbname, threshold);
+					}
+					//--------------------------------------------------------
+					// TRANSACTION Backup FAILED
+					//--------------------------------------------------------
+					else if ("WAL".equals(backupType))
+					{
+						ae = new AlarmEventLastWalBackupFailed(cm, dbname, threshold);
+					}
+					//--------------------------------------------------------
+					// ??? Backup FAILED
+					//--------------------------------------------------------
+					else
+					{
+						ae = new AlarmEventLastBackupFailed(cm, dbname, backupType, threshold);
+					}
+
+					// Set Alarm Options
+					String extendedDescText = cm.toTextTableString(DATA_RATE, r);
+					String extendedDescHtml = cm.toHtmlTableString(DATA_RATE, r, true, false, false);
+
+					ae.setExtendedDescription(extendedDescText, extendedDescHtml);
+					
+					// Since this is the ERROR LOG, we wont get at CANCEL, so let the ALARM be active for XX Minutes
+					int ttlInMinutes = Configuration.getCombinedConfiguration().getIntProperty(PROPKEY_alarm_LastBackupFailed_ttl_minutes, DEFAULT_alarm_LastBackupFailed_ttl_minutes);
+					if (ttlInMinutes > 0)
+					{
+						ae.setTimeToLive(TimeUnit.MINUTES.toMillis(ttlInMinutes));
+					}
+
+					// Information about how to disable this alarm
+					ae.createAlarmOptionsMessage(cm, "LastBackupFailed");
+
+					alarmHandler.addAlarm( ae );
+
+				} // end: errorNum == 3041
+
+			} // end: Backup
+
 		} // end: rows loop
 	}
 
-	public static final String  PROPKEY_alarm_PageErrorReadRetry    = CM_NAME + ".alarm.system.on.PageErrorReadRetry";
-	public static final boolean DEFAULT_alarm_PageErrorReadRetry    = true;
+	public static final String  PROPKEY_alarm_PageErrorReadRetry           = CM_NAME + ".alarm.system.on.PageErrorReadRetry";
+	public static final boolean DEFAULT_alarm_PageErrorReadRetry           = true;
 
-	public static final String  PROPKEY_alarm_UserConnections       = CM_NAME + ".alarm.system.on.UserConnections";
-	public static final boolean DEFAULT_alarm_UserConnections       = true;
+	public static final String  PROPKEY_alarm_UserConnections              = CM_NAME + ".alarm.system.on.UserConnections";
+	public static final boolean DEFAULT_alarm_UserConnections              = true;
 
-	public static final String  PROPKEY_alarm_TransactionLogFull    = CM_NAME + ".alarm.system.on.TransactionLogFull";
-	public static final boolean DEFAULT_alarm_TransactionLogFull    = true;
+	public static final String  PROPKEY_alarm_TransactionLogFull           = CM_NAME + ".alarm.system.on.TransactionLogFull";
+	public static final boolean DEFAULT_alarm_TransactionLogFull           = true;
 
-	public static final String  PROPKEY_alarm_Severity              = CM_NAME + ".alarm.system.if.Severity.gt";
-	public static final int     DEFAULT_alarm_Severity              = 16;
+	public static final String  PROPKEY_alarm_Severity                     = CM_NAME + ".alarm.system.if.Severity.gt";
+	public static final int     DEFAULT_alarm_Severity                     = 16;
 
-	public static final String  PROPKEY_alarm_ErrorNumberSkipList   = CM_NAME + ".alarm.system.errorNumber.skip.list";
-//	public static final String  DEFAULT_alarm_ErrorNumberSkipList   = "";
-	public static final String  DEFAULT_alarm_ErrorNumberSkipList   = "17810, 17832, 17836";
+	public static final String  PROPKEY_alarm_ErrorNumberSkipList          = CM_NAME + ".alarm.system.errorNumber.skip.list";
+//	public static final String  DEFAULT_alarm_ErrorNumberSkipList          = "";
+	public static final String  DEFAULT_alarm_ErrorNumberSkipList          = "17810, 17832, 17836";
 	// Below number are usually found when a "penetration test tool" is checking the environment
 	// Num=17810, Severity=20, Text=Could not connect because the maximum number of '1' dedicated administrator connections already exists. Before a new connection can be made, the existing dedicated administrator connection must be dropped, either by logging off or ending the process. [CLIENT: 172.25.0.49] 
 	// Num=17832, Severity=20, Text=The login packet used to open the connection is structurally invalid; the connection has been closed. Please contact the vendor of the client library. [CLIENT: 172.25.0.49] 
 	// Num=17836, Severity=20, Text=Length specified in network packet payload did not match number of bytes read; the connection has been closed. Please contact the vendor of the client library. [CLIENT: 172.25.0.49] 
 
-	public static final String  PROPKEY_alarm_ConfigChanges         = CM_NAME + ".alarm.system.on.ConfigChanges";
-	public static final boolean DEFAULT_alarm_ConfigChanges         = true;
+	public static final String  PROPKEY_alarm_ConfigChanges                = CM_NAME + ".alarm.system.on.ConfigChanges";
+	public static final boolean DEFAULT_alarm_ConfigChanges                = true;
 
-	public static final String  PROPKEY_alarm_LongIoRequests        = CM_NAME + ".alarm.system.on.LongIoRequests";
-	public static final boolean DEFAULT_alarm_LongIoRequests        = true;
+	public static final String  PROPKEY_alarm_LongIoRequests               = CM_NAME + ".alarm.system.on.LongIoRequests";
+	public static final boolean DEFAULT_alarm_LongIoRequests               = true;
 
-	public static final String  PROPKEY_alarm_StackDump             = CM_NAME + ".alarm.system.on.StackDump";
-	public static final boolean DEFAULT_alarm_StackDump             = true;
+	public static final String  PROPKEY_alarm_StackDump                    = CM_NAME + ".alarm.system.on.StackDump";
+	public static final boolean DEFAULT_alarm_StackDump                    = true;
+
+	public static final String  PROPKEY_alarm_LastBackupFailed             = CM_NAME + ".alarm.system.on.LastBackupFailed";
+	public static final boolean DEFAULT_alarm_LastBackupFailed             = true;
+
+	public static final String  PROPKEY_alarm_LastBackupFailed_ttl_minutes = CM_NAME + ".alarm.system.on.LastBackupFailed.ttl.minutes";
+	public static final int     DEFAULT_alarm_LastBackupFailed_ttl_minutes = 30;
 
 	@Override
 	public List<CmSettingsHelper> getLocalAlarmSettings()
@@ -701,15 +810,18 @@ extends CountersModelAppend
 
 		CmSettingsHelper.Type isAlarmSwitch = CmSettingsHelper.Type.IS_ALARM_SWITCH;
 
-		list.add(new CmSettingsHelper("PageErrorReadRetry"     , isAlarmSwitch, PROPKEY_alarm_PageErrorReadRetry , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_PageErrorReadRetry , DEFAULT_alarm_PageErrorReadRetry ), DEFAULT_alarm_PageErrorReadRetry , "On Error 825, send 'AlarmEventErrorLogEntry'. Note that this is 'only' severity 10... Hence: We are *UPPGRADING* it to a more severe error" ));
-		list.add(new CmSettingsHelper("UserConnections"        , isAlarmSwitch, PROPKEY_alarm_UserConnections    , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_UserConnections    , DEFAULT_alarm_UserConnections    ), DEFAULT_alarm_UserConnections    , "On Error 17300 or 17809, send 'AlarmEventConfigResourceIsUsedUp'." ));
-		list.add(new CmSettingsHelper("TransactionLogFull"     , isAlarmSwitch, PROPKEY_alarm_TransactionLogFull , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_TransactionLogFull , DEFAULT_alarm_TransactionLogFull ), DEFAULT_alarm_TransactionLogFull , "On Error 9002, send 'AlarmEventFullTranLog'." ));
-		list.add(new CmSettingsHelper("ConfigChanges"          , isAlarmSwitch, PROPKEY_alarm_ConfigChanges      , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_ConfigChanges      , DEFAULT_alarm_ConfigChanges      ), DEFAULT_alarm_ConfigChanges      , "On error log message 'The configuration option '.*' has been changed', send 'AlarmEventConfigChanges'." ));
-		list.add(new CmSettingsHelper("LongIoRequests"         , isAlarmSwitch, PROPKEY_alarm_LongIoRequests     , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_LongIoRequests     , DEFAULT_alarm_LongIoRequests     ), DEFAULT_alarm_LongIoRequests     , "On error log message 'I/O requests taking longer than 15 seconds to complete', send 'AlarmEventErrorLogEntry'." ));
-		list.add(new CmSettingsHelper("StackDump"              , isAlarmSwitch, PROPKEY_alarm_StackDump          , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_StackDump          , DEFAULT_alarm_StackDump          ), DEFAULT_alarm_StackDump          , "On error log message '**Dump thread - ', collect the dump text and send 'AlarmEventStackDump'." ));
+		list.add(new CmSettingsHelper("PageErrorReadRetry"     , isAlarmSwitch, PROPKEY_alarm_PageErrorReadRetry          , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_PageErrorReadRetry          , DEFAULT_alarm_PageErrorReadRetry          ), DEFAULT_alarm_PageErrorReadRetry          , "On Error 825, send 'AlarmEventErrorLogEntry'. Note that this is 'only' severity 10... Hence: We are *UPPGRADING* it to a more severe error" ));
+		list.add(new CmSettingsHelper("UserConnections"        , isAlarmSwitch, PROPKEY_alarm_UserConnections             , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_UserConnections             , DEFAULT_alarm_UserConnections             ), DEFAULT_alarm_UserConnections             , "On Error 17300 or 17809, send 'AlarmEventConfigResourceIsUsedUp'." ));
+		list.add(new CmSettingsHelper("TransactionLogFull"     , isAlarmSwitch, PROPKEY_alarm_TransactionLogFull          , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_TransactionLogFull          , DEFAULT_alarm_TransactionLogFull          ), DEFAULT_alarm_TransactionLogFull          , "On Error 9002, send 'AlarmEventFullTranLog'." ));
+		list.add(new CmSettingsHelper("ConfigChanges"          , isAlarmSwitch, PROPKEY_alarm_ConfigChanges               , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_ConfigChanges               , DEFAULT_alarm_ConfigChanges               ), DEFAULT_alarm_ConfigChanges               , "On error log message 'The configuration option '.*' has been changed', send 'AlarmEventConfigChanges'." ));
+		list.add(new CmSettingsHelper("LongIoRequests"         , isAlarmSwitch, PROPKEY_alarm_LongIoRequests              , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_LongIoRequests              , DEFAULT_alarm_LongIoRequests              ), DEFAULT_alarm_LongIoRequests              , "On error log message 'I/O requests taking longer than 15 seconds to complete', send 'AlarmEventErrorLogEntry'." ));
+		list.add(new CmSettingsHelper("StackDump"              , isAlarmSwitch, PROPKEY_alarm_StackDump                   , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_StackDump                   , DEFAULT_alarm_StackDump                   ), DEFAULT_alarm_StackDump                   , "On error log message '**Dump thread - ', collect the dump text and send 'AlarmEventStackDump'." ));
 
-		list.add(new CmSettingsHelper("Severity"               , isAlarmSwitch, PROPKEY_alarm_Severity           , Integer.class, conf.getIntProperty    (PROPKEY_alarm_Severity           , DEFAULT_alarm_Severity           ), DEFAULT_alarm_Severity           , "If 'Severity' is greater than ## then send 'AlarmEventErrorLogEntry'." ));
-		list.add(new CmSettingsHelper("Severity SkipList ErrorNumber(s)",       PROPKEY_alarm_ErrorNumberSkipList, String .class, conf.getProperty       (PROPKEY_alarm_ErrorNumberSkipList, DEFAULT_alarm_ErrorNumberSkipList), DEFAULT_alarm_ErrorNumberSkipList, "Skip errors number in this list, that is if Severity is above that rule. format(comma separated list of numbers): 123, 321, 231" ));
+		list.add(new CmSettingsHelper("Severity"               , isAlarmSwitch, PROPKEY_alarm_Severity                    , Integer.class, conf.getIntProperty    (PROPKEY_alarm_Severity                    , DEFAULT_alarm_Severity                    ), DEFAULT_alarm_Severity                    , "If 'Severity' is greater than ## then send 'AlarmEventErrorLogEntry'." ));
+		list.add(new CmSettingsHelper("Severity SkipList ErrorNumber(s)",       PROPKEY_alarm_ErrorNumberSkipList         , String .class, conf.getProperty       (PROPKEY_alarm_ErrorNumberSkipList         , DEFAULT_alarm_ErrorNumberSkipList         ), DEFAULT_alarm_ErrorNumberSkipList         , "Skip errors number in this list, that is if Severity is above that rule. format(comma separated list of numbers): 123, 321, 231" ));
+
+		list.add(new CmSettingsHelper("LastBackupFailed"       , isAlarmSwitch, PROPKEY_alarm_LastBackupFailed            , Boolean.class, conf.getBooleanProperty(PROPKEY_alarm_LastBackupFailed            , DEFAULT_alarm_LastBackupFailed            ), DEFAULT_alarm_LastBackupFailed            , "On error log message 'Msg=3041. BACKUP failed to complete the command ...', send 'AlarmEventLastDbBackupFailed' or 'AlarmEventLastWalBackupFailed' or 'AlarmEventLastBackupFailed'." ));
+		list.add(new CmSettingsHelper("LastBackupFailed TTL Minutes"          , PROPKEY_alarm_LastBackupFailed_ttl_minutes, Integer.class, conf.getIntProperty    (PROPKEY_alarm_LastBackupFailed_ttl_minutes, DEFAULT_alarm_LastBackupFailed_ttl_minutes), DEFAULT_alarm_LastBackupFailed_ttl_minutes, "On 'LastBackupFailed', how many minutes should the alarm be active for" ));
 
 		return list;
 	}


### PR DESCRIPTION
DbxCentral
 * Active Statements -- Show any problems like 'TimeOutExceptions'... (by calling the collectors management api: /api/cc/mgt/cm/list, so it needs a existing recording database)

AseTune
 * Better detection of LastBackupFailed... It can now alarm for both DB and WAL

SqlServerTune
 * CmErrorLog -- New Alarm: LastBackupFailed -- AlarmEventLastDbBackupFailed, AlarmEventLastWalBackupFailed or AlarmEventLastBackupFailed (default TimeToLive is 30 minutes, which can be changed with: CmErrorLog.alarm.system.on.LastBackupFailed.ttl.minutes)